### PR TITLE
Info.plist: enable GCSupportsGameMode

### DIFF
--- a/Limelight/Limelight-Info.plist
+++ b/Limelight/Limelight-Info.plist
@@ -35,6 +35,8 @@
 	</array>
 	<key>GCSupportsControllerUserInteraction</key>
 	<true/>
+	<key>GCSupportsGameMode</key>
+	<true/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/Moonlight TV/Info.plist
+++ b/Moonlight TV/Info.plist
@@ -29,6 +29,8 @@
 	</array>
 	<key>GCSupportsControllerUserInteraction</key>
 	<true/>
+	<key>GCSupportsGameMode</key>
+	<true/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
enables the iOS 18 feature Game Mode, which optimizes latency and performance.

reference: https://developer.apple.com/documentation/xcode/build-settings-reference#Supports-Game-Mode