### PR TITLE
Fix homebar handling

### DIFF
--- a/VoidLink/ViewControllers/StreamFrameViewController.m
+++ b/VoidLink/ViewControllers/StreamFrameViewController.m
@@ -1343,7 +1343,7 @@
 }
 
 - (BOOL)prefersHomeIndicatorAutoHidden {
-    if ( [_streamView getCurrentOscState] == OnScreenControlsLevelOff &&
+    if ( [_controllerSupport getConnectedGamepadCount] > 0 && [_streamView getCurrentOscState] == OnScreenControlsLevelOff &&
         _userIsInteracting == NO) {
         // Autohide the home bar when a gamepad is connected
         // and the on-screen controls are disabled. We can't


### PR DESCRIPTION
Closes #97 

Previously the check was removed to hide the homebar without needing a controller connected, but it's causing unexpected exit of the app when clicking on the homebar area, revert the changes for now but might need more investigation

