### PR TITLE
屏幕按键布局配对

### DIFF
--- a/VoidLink/Base.lproj/iPad.storyboard
+++ b/VoidLink/Base.lproj/iPad.storyboard
@@ -1730,40 +1730,55 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView opaque="NO" clearsContextBeforeDrawing="NO" alpha="0.5" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="BA3-hd-bDp">
-                                <rect key="frame" x="198.5" y="60" width="736" height="634"/>
+                                <rect key="frame" x="198.5" y="60" width="736" height="529"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </tableView>
-                            <navigationBar clipsSubviews="YES" alpha="0.69999999999999996" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="62V-DN-FUk">
+                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vDc-Mf-i9f">
+                                <rect key="frame" x="198.5" y="539" width="736" height="50"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <items>
+                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="HEm-3A-WOn"/>
+                                    <barButtonItem title="Pair Rotational Layout" id="aqk-2z-ycj">
+                                        <connections>
+                                            <action selector="pairRotationalToolbarTapped:" destination="Atv-Nj-0qv" id="Bb1-bt-lap"/>
+                                        </connections>
+                                    </barButtonItem>
+                                    <barButtonItem title="Item" image="questionmark.circle" catalog="system" id="7rN-Nu-Vqg"/>
+                                </items>
+                                <color key="tintColor" systemColor="systemTealColor"/>
+                            </toolbar>
+                            <navigationBar clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="62V-DN-FUk">
                                 <rect key="frame" x="198.5" y="60" width="736" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="lQr-5u-g05"/>
                                 </constraints>
+                                <color key="tintColor" systemColor="systemTealColor"/>
                                 <items>
                                     <navigationItem title="Widget Profiles" id="Q2V-XF-4jq">
                                         <leftBarButtonItems>
-                                            <barButtonItem title="Exit" width="45" style="plain" id="czn-mj-8d1">
+                                            <barButtonItem title="Exit" image="xmark" catalog="system" width="32" style="plain" id="czn-mj-8d1">
                                                 <connections>
                                                     <action selector="exitTapped:" destination="Atv-Nj-0qv" id="IvQ-c3-bmW"/>
                                                 </connections>
                                             </barButtonItem>
-                                            <barButtonItem title="ExportAll" width="70" style="plain" id="Bhn-IO-Wlt" userLabel="Export Data">
+                                            <barButtonItem title="ExportAll" image="square.and.arrow.up" catalog="system" width="48" style="plain" id="Bhn-IO-Wlt" userLabel="Export Data">
                                                 <connections>
                                                     <action selector="exportDataTapped:" destination="Atv-Nj-0qv" id="pwG-sO-9he"/>
                                                 </connections>
                                             </barButtonItem>
-                                            <barButtonItem title="Import" width="48" style="plain" id="CpY-Sb-BDc" userLabel="Import Data">
+                                            <barButtonItem title="Import" image="square.and.arrow.down" catalog="system" width="48" style="plain" id="CpY-Sb-BDc" userLabel="Import Data">
                                                 <connections>
                                                     <action selector="importDataTapped:" destination="Atv-Nj-0qv" id="Uq0-Ct-LbS"/>
                                                 </connections>
                                             </barButtonItem>
                                         </leftBarButtonItems>
                                         <rightBarButtonItems>
-                                            <barButtonItem title="Duplicate" width="80" style="plain" id="P34-hO-6cX">
+                                            <barButtonItem title="Duplicate" image="plus.square.on.square" catalog="system" width="32" style="plain" id="P34-hO-6cX">
                                                 <connections>
                                                     <action selector="duplicateTapped:" destination="Atv-Nj-0qv" id="Ymg-8q-iIc"/>
                                                 </connections>
                                             </barButtonItem>
-                                            <barButtonItem title="Delete" width="80" style="plain" id="egC-9E-zS4" userLabel="Delete">
+                                            <barButtonItem title="Delete" image="trash" catalog="system" width="48" style="plain" id="egC-9E-zS4" userLabel="Delete">
                                                 <connections>
                                                     <action selector="deleteTapped:" destination="Atv-Nj-0qv" id="UpR-VB-qez"/>
                                                 </connections>
@@ -1776,11 +1791,15 @@
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="62V-DN-FUk" firstAttribute="top" secondItem="BA3-hd-bDp" secondAttribute="top" id="600-lH-rte"/>
+                            <constraint firstItem="vDc-Mf-i9f" firstAttribute="centerX" secondItem="PlJ-LJ-d1p" secondAttribute="centerX" id="Eg1-Re-cZ3"/>
                             <constraint firstItem="62V-DN-FUk" firstAttribute="width" secondItem="PlJ-LJ-d1p" secondAttribute="width" multiplier="0.65" id="OWL-Yd-KfG"/>
+                            <constraint firstAttribute="bottom" secondItem="BA3-hd-bDp" secondAttribute="bottom" constant="155" id="XO8-5C-CfC"/>
                             <constraint firstItem="BA3-hd-bDp" firstAttribute="centerX" secondItem="PlJ-LJ-d1p" secondAttribute="centerX" id="Xte-bA-pFb"/>
+                            <constraint firstItem="vDc-Mf-i9f" firstAttribute="trailing" secondItem="BA3-hd-bDp" secondAttribute="trailing" id="Y2l-Ud-kez"/>
+                            <constraint firstItem="vDc-Mf-i9f" firstAttribute="leading" secondItem="BA3-hd-bDp" secondAttribute="leading" id="aGm-dh-mjs"/>
+                            <constraint firstItem="vDc-Mf-i9f" firstAttribute="bottom" secondItem="BA3-hd-bDp" secondAttribute="bottom" id="bPh-3D-nAB"/>
                             <constraint firstItem="BA3-hd-bDp" firstAttribute="width" secondItem="PlJ-LJ-d1p" secondAttribute="width" multiplier="0.65" id="eQf-gF-6kX"/>
                             <constraint firstItem="BA3-hd-bDp" firstAttribute="top" secondItem="PlJ-LJ-d1p" secondAttribute="top" constant="60" id="eje-7O-RaF"/>
-                            <constraint firstItem="BA3-hd-bDp" firstAttribute="bottom" secondItem="PlJ-LJ-d1p" secondAttribute="bottom" constant="-50" id="j96-Mz-xiG"/>
                             <constraint firstItem="62V-DN-FUk" firstAttribute="centerX" secondItem="PlJ-LJ-d1p" secondAttribute="centerX" id="qmh-Pp-B9S"/>
                         </constraints>
                     </view>
@@ -1788,13 +1807,16 @@
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <size key="freeformSize" width="1133" height="744"/>
                     <connections>
+                        <outlet property="helpToolbarItem" destination="7rN-Nu-Vqg" id="OJo-qr-4zh"/>
+                        <outlet property="pairRotationalToolbarItem" destination="aqk-2z-ycj" id="nAg-87-HmM"/>
                         <outlet property="profileTableViewNavigationBar" destination="62V-DN-FUk" id="c3i-qa-4ix"/>
+                        <outlet property="systemBottomToolbar" destination="vDc-Mf-i9f" id="UJt-sa-JKG"/>
                         <outlet property="tableView" destination="BA3-hd-bDp" id="Jzl-sP-ANp"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="K4u-Tz-tXU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3742" y="955"/>
+            <point key="canvasLocation" x="3741.3669064748206" y="954.54545454545462"/>
         </scene>
     </scenes>
     <resources>
@@ -1804,11 +1826,17 @@
         <image name="arrow.left.square.fill" catalog="system" width="128" height="114"/>
         <image name="arrow.uturn.backward" width="19.06089973449707" height="18.594499588012695"/>
         <image name="plus.rectangle.fill.on.rectangle.fill" catalog="system" width="128" height="102"/>
+        <image name="plus.square.on.square" catalog="system" width="128" height="116"/>
+        <image name="questionmark.circle" catalog="system" width="128" height="123"/>
         <image name="rectangle.and.pencil.and.ellipsis" width="36.005599975585938" height="24.95680046081543"/>
+        <image name="square.and.arrow.down" catalog="system" width="114" height="128"/>
         <image name="square.and.arrow.down.fill" catalog="system" width="121" height="128"/>
+        <image name="square.and.arrow.up" catalog="system" width="110" height="128"/>
+        <image name="trash" catalog="system" width="117" height="128"/>
         <image name="trash.fill" catalog="system" width="117" height="128"/>
         <image name="tray.full.fill" catalog="system" width="128" height="88"/>
         <image name="video.and.waveform" catalog="system" width="128" height="94"/>
+        <image name="xmark" catalog="system" width="128" height="113"/>
         <systemColor name="linkColor">
             <color red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/VoidLink/Base.lproj/iPhone.storyboard
+++ b/VoidLink/Base.lproj/iPhone.storyboard
@@ -682,37 +682,52 @@
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="sectionIndexBackgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </tableView>
+                            <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zVw-SV-RKE">
+                                <rect key="frame" x="80" y="324" width="692" height="49"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <items>
+                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="eSQ-dI-tRL"/>
+                                    <barButtonItem title="Pair Rotational Layout" id="BIT-3F-bXp">
+                                        <connections>
+                                            <action selector="pairRotationalToolbarTapped:" destination="0K8-kQ-xlN" id="He6-NS-IgX"/>
+                                        </connections>
+                                    </barButtonItem>
+                                    <barButtonItem title="Item" image="questionmark.circle" catalog="system" id="3bT-QF-0LO"/>
+                                </items>
+                                <color key="tintColor" systemColor="systemTealColor"/>
+                            </toolbar>
                             <navigationBar alpha="0.69999999999999996" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zsA-6X-Qc5">
                                 <rect key="frame" x="80" y="112" width="692" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="R90-2b-UrU"/>
                                 </constraints>
+                                <color key="tintColor" systemColor="systemTealColor"/>
                                 <items>
                                     <navigationItem title="Controller &amp; Widget Profiles" id="5pN-Sn-SCN">
                                         <leftBarButtonItems>
-                                            <barButtonItem title="Exit" id="sUC-Ur-7eI">
+                                            <barButtonItem title="Exit" image="xmark" catalog="system" id="sUC-Ur-7eI">
                                                 <connections>
                                                     <action selector="exitTapped:" destination="0K8-kQ-xlN" id="lAJ-eO-ez7"/>
                                                 </connections>
                                             </barButtonItem>
-                                            <barButtonItem title="ExportAll" id="D9X-7p-9oc">
+                                            <barButtonItem title="ExportAll" image="square.and.arrow.up" catalog="system" id="D9X-7p-9oc">
                                                 <connections>
                                                     <action selector="exportDataTapped:" destination="0K8-kQ-xlN" id="Sam-Ct-kqC"/>
                                                 </connections>
                                             </barButtonItem>
-                                            <barButtonItem title="Import" id="Z9M-yq-an2">
+                                            <barButtonItem title="Import" image="square.and.arrow.down" catalog="system" id="Z9M-yq-an2">
                                                 <connections>
                                                     <action selector="importDataTapped:" destination="0K8-kQ-xlN" id="OaF-8j-7Wy"/>
                                                 </connections>
                                             </barButtonItem>
                                         </leftBarButtonItems>
                                         <rightBarButtonItems>
-                                            <barButtonItem title="Duplicate" width="80" style="plain" id="bue-hp-CWD">
+                                            <barButtonItem title="Duplicate" image="plus.square.on.square" catalog="system" width="80" style="plain" id="bue-hp-CWD">
                                                 <connections>
                                                     <action selector="duplicateTapped:" destination="0K8-kQ-xlN" id="Gb7-bx-nxp"/>
                                                 </connections>
                                             </barButtonItem>
-                                            <barButtonItem title="Delete" width="80" style="plain" id="ghM-zc-sr6">
+                                            <barButtonItem title="Delete" image="trash" catalog="system" width="80" style="plain" id="ghM-zc-sr6">
                                                 <connections>
                                                     <action selector="deleteTapped:" destination="0K8-kQ-xlN" id="h6N-Gl-oiW"/>
                                                 </connections>
@@ -727,15 +742,22 @@
                             <constraint firstItem="zsA-6X-Qc5" firstAttribute="leading" secondItem="bTO-bs-q93" secondAttribute="leading" constant="80" id="0Fi-vo-M6P"/>
                             <constraint firstAttribute="bottom" secondItem="kTH-ez-aKD" secondAttribute="bottom" constant="20" symbolic="YES" id="1FM-gO-6PR"/>
                             <constraint firstAttribute="trailing" secondItem="kTH-ez-aKD" secondAttribute="trailing" constant="80" id="ArS-pG-QUR"/>
+                            <constraint firstItem="zVw-SV-RKE" firstAttribute="centerX" secondItem="kTH-ez-aKD" secondAttribute="centerX" id="EFY-CF-949"/>
+                            <constraint firstItem="zVw-SV-RKE" firstAttribute="trailing" secondItem="kTH-ez-aKD" secondAttribute="trailing" id="KAw-L3-9lL"/>
                             <constraint firstItem="kTH-ez-aKD" firstAttribute="leading" secondItem="bTO-bs-q93" secondAttribute="leading" constant="80" id="Ujg-Sw-4hq"/>
                             <constraint firstAttribute="trailing" secondItem="zsA-6X-Qc5" secondAttribute="trailing" constant="80" id="YKK-qs-mZR"/>
+                            <constraint firstItem="zVw-SV-RKE" firstAttribute="leading" secondItem="kTH-ez-aKD" secondAttribute="leading" id="f7j-gx-dZY"/>
                             <constraint firstItem="zsA-6X-Qc5" firstAttribute="top" secondItem="bTO-bs-q93" secondAttribute="topMargin" constant="16" id="gZg-eJ-rnP"/>
+                            <constraint firstItem="zVw-SV-RKE" firstAttribute="bottom" secondItem="kTH-ez-aKD" secondAttribute="bottom" id="tF8-2N-HBS"/>
                             <constraint firstItem="kTH-ez-aKD" firstAttribute="top" secondItem="zsA-6X-Qc5" secondAttribute="top" id="txs-Df-ANQ"/>
                         </constraints>
                     </view>
                     <size key="freeformSize" width="852" height="393"/>
                     <connections>
+                        <outlet property="helpToolbarItem" destination="3bT-QF-0LO" id="SxA-se-l77"/>
+                        <outlet property="pairRotationalToolbarItem" destination="BIT-3F-bXp" id="y7a-7T-Bki"/>
                         <outlet property="profileTableViewNavigationBar" destination="zsA-6X-Qc5" id="13u-ks-fVC"/>
+                        <outlet property="systemBottomToolbar" destination="zVw-SV-RKE" id="QpS-Fx-fqe"/>
                         <outlet property="tableView" destination="kTH-ez-aKD" id="pqR-CC-Kfh"/>
                     </connections>
                 </viewController>
@@ -1838,10 +1860,16 @@
         <image name="arrow.left.square.fill" catalog="system" width="128" height="114"/>
         <image name="arrow.uturn.backward" catalog="system" width="128" height="113"/>
         <image name="plus.rectangle.fill.on.rectangle.fill" catalog="system" width="128" height="102"/>
+        <image name="plus.square.on.square" catalog="system" width="128" height="116"/>
+        <image name="questionmark.circle" catalog="system" width="128" height="123"/>
         <image name="rectangle.and.pencil.and.ellipsis" width="36.005599975585938" height="24.95680046081543"/>
+        <image name="square.and.arrow.down" catalog="system" width="114" height="128"/>
         <image name="square.and.arrow.down.fill" catalog="system" width="121" height="128"/>
+        <image name="square.and.arrow.up" catalog="system" width="110" height="128"/>
+        <image name="trash" catalog="system" width="117" height="128"/>
         <image name="trash.fill" catalog="system" width="117" height="128"/>
         <image name="tray.full.fill" catalog="system" width="128" height="88"/>
+        <image name="xmark" catalog="system" width="128" height="113"/>
         <systemColor name="linkColor">
             <color red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/VoidLink/Input/CustomOSC/OSCProfile.h
+++ b/VoidLink/Input/CustomOSC/OSCProfile.h
@@ -26,6 +26,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property NSMutableArray <OnScreenButtonState *> *buttonStates;
 @property BOOL isSelected;
 
+// 配对布局相关属性
+@property (nullable) NSString *pairedProfileName;  // 配对的布局名称
+@property BOOL isLandscapeLayout;                  // 是否为横屏布局
+@property BOOL isPaired;                           // 是否已配对
+
 - (id) initWithName:(NSString*)name buttonStates:(NSMutableArray*)buttonStates isSelected:(BOOL)isSelected;
 
 + (BOOL) supportsSecureCoding;

--- a/VoidLink/Input/CustomOSC/OSCProfile.m
+++ b/VoidLink/Input/CustomOSC/OSCProfile.m
@@ -18,6 +18,11 @@
         self.name = name;
         self.buttonStates = buttonStates;
         self.isSelected = isSelected;
+        
+        // 初始化配对相关属性
+        self.pairedProfileName = nil;
+        self.isLandscapeLayout = NO;
+        self.isPaired = NO;
     }
     
     return self;
@@ -31,6 +36,11 @@
     [encoder encodeObject:self.name forKey:@"name"];
     [encoder encodeObject:self.buttonStates forKey:@"buttonStates"];
     [encoder encodeBool:self.isSelected forKey:@"isSelected"];
+    
+    // 编码配对相关属性
+    [encoder encodeObject:self.pairedProfileName forKey:@"pairedProfileName"];
+    [encoder encodeBool:self.isLandscapeLayout forKey:@"isLandscapeLayout"];
+    [encoder encodeBool:self.isPaired forKey:@"isPaired"];
 }
 
 - (id) initWithCoder:(NSCoder*)decoder {
@@ -38,6 +48,22 @@
         self.name = [decoder decodeObjectForKey:@"name"];
         self.buttonStates = [decoder decodeObjectForKey:@"buttonStates"];
         self.isSelected = [decoder decodeBoolForKey:@"isSelected"];
+        
+        // 解码配对相关属性，提供默认值以保持向后兼容性
+        self.pairedProfileName = [decoder decodeObjectForKey:@"pairedProfileName"];
+        self.isLandscapeLayout = [decoder decodeBoolForKey:@"isLandscapeLayout"];
+        self.isPaired = [decoder decodeBoolForKey:@"isPaired"];
+        
+        // 验证必要的数据是否有效
+        if (self.name == nil) {
+            NSLog(@"警告：OSCProfile解码时name为nil，使用默认名称");
+            self.name = @"未命名配置";
+        }
+        
+        if (self.buttonStates == nil) {
+            NSLog(@"警告：OSCProfile解码时buttonStates为nil，使用空数组");
+            self.buttonStates = [[NSMutableArray alloc] init];
+        }
     }
     
     return self;

--- a/VoidLink/Input/CustomOSC/OSCProfilesManager.h
+++ b/VoidLink/Input/CustomOSC/OSCProfilesManager.h
@@ -72,6 +72,48 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL) profileNameAlreadyExist:(NSString*)name;
 - (OSCProfile *) findProfileByName:(NSString*) name inProfileArray:(NSMutableArray*)profiles;
 
+#pragma mark - Pairing Management
+/**
+ * 创建两个布局之间的配对关系
+ */
+- (BOOL) pairProfile:(NSString*)profile1Name withProfile:(NSString*)profile2Name isProfile1Landscape:(BOOL)isLandscape;
+
+/**
+ * 解除配对关系
+ */
+- (BOOL) unpairProfile:(NSString*)profileName;
+
+/**
+ * 获取指定布局的配对布局
+ */
+- (OSCProfile *) getPairedProfile:(NSString*)profileName;
+
+/**
+ * 检查布局是否已配对
+ */
+- (BOOL) isProfilePaired:(NSString*)profileName;
+
+/**
+ * 根据当前屏幕方向获取应该使用的布局
+ */
+- (OSCProfile *) getProfileForCurrentOrientation:(NSString*)profileName isLandscape:(BOOL)isLandscape;
+
+/**
+ * 获取当前屏幕方向
+ */
+- (BOOL) isCurrentOrientationLandscape;
+
+/**
+ * 获取所有可用于配对的布局（排除当前选中和已配对的布局）
+ */
+- (NSMutableArray *) getAvailableProfilesForPairing:(NSString*)currentProfileName;
+
+#pragma mark - Template Management
+/**
+ * 检查指定名称的布局是否为模板布局（不可编辑、删除或配对）
+ */
+- (BOOL) isTemplateProfile:(NSString*)profileName;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/VoidLink/Input/CustomOSC/OSCProfilesManager.m
+++ b/VoidLink/Input/CustomOSC/OSCProfilesManager.m
@@ -68,10 +68,25 @@ static CGRect layoutViewBounds;
 - (NSMutableArray *) encodedProfilesFromArray:(NSMutableArray *)profiles {
     
     NSMutableArray *profilesEncoded = [[NSMutableArray alloc] init];
+    
+    if (profiles == nil) {
+        NSLog(@"警告：尝试编码nil profiles数组，返回空数组");
+        return profilesEncoded;
+    }
+    
     /* encode each profile and add them back into an array */
-    for (OSCProfile *profile in profiles) {   //
+    for (OSCProfile *profile in profiles) {
+        if (profile == nil) {
+            NSLog(@"警告：跳过nil profile对象");
+            continue;
+        }
+        
         NSData *profileEncoded = [NSKeyedArchiver archivedDataWithRootObject:profile requiringSecureCoding:YES error:nil];
-        [profilesEncoded addObject:profileEncoded];
+        if (profileEncoded != nil) {
+            [profilesEncoded addObject:profileEncoded];
+        } else {
+            NSLog(@"警告：profile编码失败，跳过该profile: %@", profile.name ?: @"未命名");
+        }
     }
     
     return profilesEncoded;
@@ -86,8 +101,20 @@ static CGRect layoutViewBounds;
     NSInteger selectedIndex = [self getIndexOfSelectedProfile];
     
     /* Remove the selected profile */
-    if(selectedIndex != 0) [profiles removeObjectAtIndex:selectedIndex]; //deleting default profile (index 0) is not allowed
-    else {
+    if(selectedIndex != 0) {
+        OSCProfile *profileToDelete = [profiles objectAtIndex:selectedIndex];
+        
+        // 如果要删除的布局已配对，需要清理配对关系
+        if (profileToDelete.isPaired) {
+            [self unpairProfile:profileToDelete.name];
+            // 重新获取profiles，因为unpairProfile会更新存储
+            profiles = [self getAllProfiles];
+            // 重新计算selectedIndex，因为profiles可能已经改变
+            selectedIndex = [self getIndexOfSelectedProfile];
+        }
+        
+        [profiles removeObjectAtIndex:selectedIndex];
+    } else {
         NSLog(@"Default profile!"); // to be updated here.
     }
     
@@ -189,9 +216,24 @@ static CGRect layoutViewBounds;
 - (NSMutableArray *) getAllProfiles {
     
     NSData *profilesArrayEncoded = [[NSUserDefaults standardUserDefaults] objectForKey: @"OSCProfiles"];    // Get the encoded array of encoded OSC profiles from persistent storage
+    
+    // 如果没有保存的配置文件数据，返回空数组
+    if (profilesArrayEncoded == nil) {
+        NSLog(@"没有找到保存的配置文件数据，返回空数组");
+        _currentProfiles = [[NSMutableArray alloc] init];
+        return _currentProfiles;
+    }
+    
     NSSet *classes = [NSSet setWithObjects:[NSString class], [NSMutableData class], [NSMutableArray class], [OSCProfile class], [OnScreenButtonState class], nil];
     
     NSMutableArray *profilesEncoded = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes fromData:profilesArrayEncoded error:nil];    // Decode the encoded array itself, NOT the objects contained in the array
+    
+    // 如果解码失败，返回空数组
+    if (profilesEncoded == nil) {
+        NSLog(@"配置文件数据解码失败，返回空数组");
+        _currentProfiles = [[NSMutableArray alloc] init];
+        return _currentProfiles;
+    }
     
     /* Decode each of the encoded profiles, place them into an array, then return the array */
     NSMutableArray *profilesDecoded = [[NSMutableArray alloc] init];
@@ -199,7 +241,11 @@ static CGRect layoutViewBounds;
     for (NSData *profileEncoded in profilesEncoded) {
         
         profileDecoded = [NSKeyedUnarchiver unarchivedObjectOfClasses: classes fromData:profileEncoded error: nil];
-        [profilesDecoded addObject: profileDecoded];
+        if (profileDecoded != nil) {  // 添加nil检查，防止崩溃
+            [profilesDecoded addObject: profileDecoded];
+        } else {
+            NSLog(@"警告：配置文件解码失败，跳过该配置文件");
+        }
     }
     _currentProfiles = profilesDecoded;
     return profilesDecoded;
@@ -256,17 +302,31 @@ static CGRect layoutViewBounds;
 
 - (bool) updateSelectedProfile:(NSMutableArray *) oscButtonLayers {
     NSMutableArray* buttonStatesEncoded = [self convertOnScreenControllerAndWidgetsToButtonStates:oscButtonLayers];
-    if([self getIndexOfSelectedProfile]==0) return false;
-    OSCProfile *newProfile = [[OSCProfile alloc] initWithName:[self getSelectedProfile].name
+    
+    // 检查当前选中的布局是否为模板布局
+    OSCProfile *currentProfile = [self getSelectedProfile];
+    if (currentProfile && [self isTemplateProfile:currentProfile.name]) {
+        return false;
+    }
+    OSCProfile *newProfile = [[OSCProfile alloc] initWithName:currentProfile.name
                             buttonStates:buttonStatesEncoded isSelected:YES];        // create a new 'OSCProfile'. Set the array of encoded button states created above to the 'buttonStates' property of the new profile, along with a 'name'. Set 'isSelected' argument to YES which will set this saved profile as the one that will show up in the game stream view
 
+    // 保留原有的配对信息
+    newProfile.pairedProfileName = currentProfile.pairedProfileName;
+    newProfile.isLandscapeLayout = currentProfile.isLandscapeLayout;
+    newProfile.isPaired = currentProfile.isPaired;
+    
+    NSLog(@"🔄 updateSelectedProfile - 保留配对信息: %@ -> isPaired=%@, pairedWith=%@", 
+          newProfile.name, 
+          newProfile.isPaired ? @"YES" : @"NO",
+          newProfile.pairedProfileName ?: @"nil");
     
     /* set all saved OSCProfiles 'isSelected' property to NO since the new profile you're adding will be set as the selected profile */
     NSMutableArray *profiles = [self getAllProfiles];
     for (OSCProfile *profile in profiles) {
         profile.isSelected = NO;
     }
-    [self replaceProfile:[self getSelectedProfile] withProfile:newProfile];
+    [self replaceProfile:currentProfile withProfile:newProfile];
     return true;
 }
 
@@ -275,6 +335,22 @@ static CGRect layoutViewBounds;
     NSMutableArray* buttonStatesEncoded = [self convertOnScreenControllerAndWidgetsToButtonStates:oscButtonLayers];
     OSCProfile *newProfile = [[OSCProfile alloc] initWithName:name
                             buttonStates:buttonStatesEncoded isSelected:YES];        // create a new 'OSCProfile'. Set the array of encoded button states created above to the 'buttonStates' property of the new profile, along with a 'name'. Set 'isSelected' argument to YES which will set this saved profile as the one that will show up in the game stream view
+    
+    // 如果是覆盖现有配置，保留原有的配对信息
+    if ([self profileNameAlreadyExist:name]) {
+        OSCProfile *existingProfile = [self OSCProfileWithName:name];
+        if (existingProfile) {
+            newProfile.pairedProfileName = existingProfile.pairedProfileName;
+            newProfile.isLandscapeLayout = existingProfile.isLandscapeLayout;
+            newProfile.isPaired = existingProfile.isPaired;
+            
+            NSLog(@"🔄 saveProfileWithName - 保留现有配对信息: %@ -> isPaired=%@, pairedWith=%@", 
+                  newProfile.name, 
+                  newProfile.isPaired ? @"YES" : @"NO",
+                  newProfile.pairedProfileName ?: @"nil");
+        }
+    }
+    
     /* set all saved OSCProfiles 'isSelected' property to NO since the new profile you're adding will be set as the selected profile */
     NSMutableArray *profiles = [self getAllProfiles];
     for (OSCProfile *profile in profiles) {
@@ -397,13 +473,15 @@ static CGRect layoutViewBounds;
 }
 
 - (CGFloat)normalizeSizeWidthFactor:(OnScreenWidgetView* )widget{
-    CGFloat screenWidthInPoints = CGRectGetWidth([[UIScreen mainScreen] bounds]);
-    return widget.bounds.size.width/screenWidthInPoints * 10000;
+    // 使用固定的基准宽度(1194)来避免旋转时的累积变化
+    static const CGFloat baseScreenWidth = 1194.0f;
+    return widget.bounds.size.width/baseScreenWidth * 10000;
 }
 
 - (CGFloat)normalizeSizeHeightFactor:(OnScreenWidgetView* )widget{
-    CGFloat screenWidthInPoints = CGRectGetWidth([[UIScreen mainScreen] bounds]);
-    return widget.bounds.size.height/screenWidthInPoints * 10000;
+    // 使用固定的基准宽度(1194)来避免旋转时的累积变化
+    static const CGFloat baseScreenWidth = 1194.0f;
+    return widget.bounds.size.height/baseScreenWidth * 10000;
 }
 
 
@@ -431,11 +509,189 @@ static CGRect layoutViewBounds;
 }
 
 - (OnScreenButtonState *)unarchiveButtonStateEncoded:(NSData *)data {
+    if (data == nil) {
+        NSLog(@"警告：尝试解码nil数据，返回nil");
+        return nil;
+    }
+    
     OnScreenButtonState* buttonState;
-    buttonState = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithObjects:[NSString class], [OnScreenButtonState class], nil]
+    NSSet *classes = [NSSet setWithObjects:[NSString class], [OnScreenButtonState class], nil];
+    buttonState = [NSKeyedUnarchiver unarchivedObjectOfClasses:classes
                                                     fromData:data
                                                     error:nil];
     return buttonState;
+}
+
+#pragma mark - Pairing Management
+
+- (BOOL) pairProfile:(NSString*)profile1Name withProfile:(NSString*)profile2Name isProfile1Landscape:(BOOL)isLandscape {
+    // 检查是否为模板布局
+    if ([self isTemplateProfile:profile1Name] || [self isTemplateProfile:profile2Name]) {
+        NSLog(@"配对失败：模板布局不允许配对");
+        return NO;
+    }
+    
+    NSMutableArray *profiles = [self getAllProfiles];
+    
+    OSCProfile *profile1 = [self findProfileByName:profile1Name inProfileArray:profiles];
+    OSCProfile *profile2 = [self findProfileByName:profile2Name inProfileArray:profiles];
+    
+    if (!profile1 || !profile2) {
+        NSLog(@"配对失败：找不到指定的布局");
+        return NO;
+    }
+    
+    if (profile1.isPaired || profile2.isPaired) {
+        NSLog(@"配对失败：布局已经配对");
+        return NO;
+    }
+    
+    // 设置配对关系
+    profile1.pairedProfileName = profile2Name;
+    profile1.isLandscapeLayout = isLandscape;
+    profile1.isPaired = YES;
+    
+    profile2.pairedProfileName = profile1Name;
+    profile2.isLandscapeLayout = !isLandscape;
+    profile2.isPaired = YES;
+    
+    // 保存更改
+    [self saveProfilesToStorage:profiles];
+    
+    NSLog(@"配对成功：%@ (%@) <-> %@ (%@)", 
+          profile1Name, isLandscape ? @"横屏" : @"竖屏",
+          profile2Name, !isLandscape ? @"横屏" : @"竖屏");
+    
+    return YES;
+}
+
+- (BOOL) unpairProfile:(NSString*)profileName {
+    NSMutableArray *profiles = [self getAllProfiles];
+    
+    OSCProfile *profile = [self findProfileByName:profileName inProfileArray:profiles];
+    if (!profile || !profile.isPaired) {
+        NSLog(@"解除配对失败：布局未配对");
+        return NO;
+    }
+    
+    // 找到配对的布局
+    OSCProfile *pairedProfile = [self findProfileByName:profile.pairedProfileName inProfileArray:profiles];
+    
+    // 清除配对关系
+    profile.pairedProfileName = nil;
+    profile.isLandscapeLayout = NO;
+    profile.isPaired = NO;
+    
+    if (pairedProfile) {
+        pairedProfile.pairedProfileName = nil;
+        pairedProfile.isLandscapeLayout = NO;
+        pairedProfile.isPaired = NO;
+    }
+    
+    // 保存更改
+    [self saveProfilesToStorage:profiles];
+    
+    NSLog(@"解除配对成功：%@", profileName);
+    return YES;
+}
+
+- (OSCProfile *) getPairedProfile:(NSString*)profileName {
+    NSMutableArray *profiles = [self getAllProfiles];
+    
+    OSCProfile *profile = [self findProfileByName:profileName inProfileArray:profiles];
+    if (!profile || !profile.isPaired) {
+        return nil;
+    }
+    
+    return [self findProfileByName:profile.pairedProfileName inProfileArray:profiles];
+}
+
+- (BOOL) isProfilePaired:(NSString*)profileName {
+    NSMutableArray *profiles = [self getAllProfiles];
+    OSCProfile *profile = [self findProfileByName:profileName inProfileArray:profiles];
+    return profile ? profile.isPaired : NO;
+}
+
+- (OSCProfile *) getProfileForCurrentOrientation:(NSString*)profileName isLandscape:(BOOL)isLandscape {
+    NSLog(@"🔍 getProfileForCurrentOrientation - 输入: profileName=%@, isLandscape=%@", 
+          profileName, isLandscape ? @"YES" : @"NO");
+    
+    NSMutableArray *profiles = [self getAllProfiles];
+    
+    OSCProfile *profile = [self findProfileByName:profileName inProfileArray:profiles];
+    if (!profile || !profile.isPaired) {
+        NSLog(@"🔍 布局未配对或不存在，返回原布局: %@", profile ? profile.name : @"nil");
+        return profile; // 如果未配对，返回原布局
+    }
+    
+    NSLog(@"🔍 找到配对布局 - 当前布局方向: %@, 请求方向: %@", 
+          profile.isLandscapeLayout ? @"横屏" : @"竖屏",
+          isLandscape ? @"横屏" : @"竖屏");
+    
+    // 如果当前布局的方向与请求的方向匹配，返回当前布局
+    if (profile.isLandscapeLayout == isLandscape) {
+        NSLog(@"🔍 方向匹配，返回当前布局: %@", profile.name);
+        return profile;
+    }
+    
+    // 否则返回配对的布局
+    OSCProfile *pairedProfile = [self getPairedProfile:profileName];
+    NSLog(@"🔍 方向不匹配，返回配对布局: %@", pairedProfile ? pairedProfile.name : @"nil");
+    return pairedProfile;
+}
+
+- (BOOL) isCurrentOrientationLandscape {
+    CGFloat screenHeightInPoints = CGRectGetHeight([[UIScreen mainScreen] bounds]);
+    CGFloat screenWidthInPoints = CGRectGetWidth([[UIScreen mainScreen] bounds]);
+    return screenWidthInPoints > screenHeightInPoints;
+}
+
+- (NSMutableArray *) getAvailableProfilesForPairing:(NSString*)currentProfileName {
+    NSMutableArray *allProfiles = [self getAllProfiles];
+    NSMutableArray *availableProfiles = [[NSMutableArray alloc] init];
+    
+    if (currentProfileName == nil) {
+        NSLog(@"警告：currentProfileName为nil，返回空数组");
+        return availableProfiles;
+    }
+    
+    for (OSCProfile *profile in allProfiles) {
+        if (profile == nil) {
+            NSLog(@"警告：发现nil profile，跳过");
+            continue;
+        }
+        
+        // 排除当前选中的布局、已配对的布局和模板布局
+        if (profile.name && 
+            ![profile.name isEqualToString:currentProfileName] && 
+            !profile.isPaired &&
+            ![self isTemplateProfile:profile.name]) {
+            [availableProfiles addObject:profile];
+        }
+    }
+    
+    return availableProfiles;
+}
+
+// 辅助方法：保存配置文件到存储
+- (void) saveProfilesToStorage:(NSMutableArray*)profiles {
+    NSMutableArray *profilesEncoded = [self encodedProfilesFromArray:profiles];
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:profilesEncoded requiringSecureCoding:YES error:nil];
+    [[NSUserDefaults standardUserDefaults] setObject:data forKey:@"OSCProfiles"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
+#pragma mark - Template Management
+
+- (BOOL) isTemplateProfile:(NSString*)profileName {
+    if (!profileName) {
+        return NO;
+    }
+    
+    // 检查是否为三个默认模板布局之一
+    return [profileName isEqualToString:@"Default"] ||
+           [profileName isEqualToString:DEFAULT_TEMPLATE_NAME1] ||
+           [profileName isEqualToString:DEFAULT_TEMPLATE_NAME2];
 }
 
 @end

--- a/VoidLink/Input/OnScreenWidgetView.swift
+++ b/VoidLink/Input/OnScreenWidgetView.swift
@@ -399,9 +399,10 @@ import UIKit
     }
     
     private func denormalizeSize(sizeFactor:CGFloat) -> CGFloat {
-        let screenWidthInPoints = UIScreen.main.bounds.width
-        // return CGFloat(Int(sizeFactor/10000*screenWidthInPoints/2)*2);
-        return nearestEven(sizeFactor/10000*screenWidthInPoints);
+        // 使用固定的基准宽度(1194)来避免旋转时的累积变化
+        let baseScreenWidth: CGFloat = 1194.0
+        // return CGFloat(Int(sizeFactor/10000*baseScreenWidth/2)*2);
+        return nearestEven(sizeFactor/10000*baseScreenWidth);
     }
     
     private func changeAndActivateContraints(){

--- a/VoidLink/Localization/LocalizationHelper.m
+++ b/VoidLink/Localization/LocalizationHelper.m
@@ -10,11 +10,68 @@
 
 @implementation LocalizationHelper
 
+/* Fallback localized strings for keys not found in Localizable.xcstrings.
+ * This allows us to ship new strings without immediately editing the catalog.
+ */
++ (NSString *)osc_languageCodePrefix {
+    NSString *lang = [[NSLocale preferredLanguages] firstObject] ?: @"en";
+    if ([lang hasPrefix:@"zh"]) return @"zh";
+    return @"en";
+}
+
++ (NSDictionary *)osc_fallbackDictionaryForLanguage:(NSString *)prefix {
+    static NSDictionary *zhDict; static NSDictionary *enDict; static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        zhDict = @{
+            @"PairingHelpTitle": @"配对布局说明",
+            @"PairingHelpMessage": @"你可以提前创建好偏好的横屏和竖屏布局，在这里进行绑定。绑定后，旋转屏幕将在绑定的两个布局之间切换。\n注意：默认布局和模板布局不支持绑定。",
+            @"Unpair": @"解除配对",
+            @"BindOrientationLayout:%@": @"绑定%@布局",
+            @"PortraitShort": @"竖屏",
+            @"LandscapeShort": @"横屏",
+            @"ConfirmDelete": @"确认删除",
+            @"ConfirmDeleteProfile:%@": @"确定要删除布局'%@'吗？",
+            @"DeleteTemplateNotAllowed:%@": @"删除'%@'模板布局是不被允许的",
+            @"UnnamedProfile": @"未命名配置",
+            @"OK": @"我知道了",
+            @"Save": @"保存",
+            @"Cancel": @"取消",
+            @"CurrentLayoutShort": @"当前布局",
+            @"SelectLayoutToPair:%@": @"选择要绑定的%@布局"
+        };
+        enDict = @{
+            @"PairingHelpTitle": @"Pairing Help",
+            @"PairingHelpMessage": @"You can pre-create preferred landscape and portrait layouts and pair them here. After pairing, rotating the device switches between the two layouts.\nNote: Default and template layouts do not support pairing.",
+            @"Unpair": @"Unpair",
+            @"BindOrientationLayout:%@": @"Pair %@",
+            @"PortraitShort": @"Portrait",
+            @"LandscapeShort": @"Landscape",
+            @"ConfirmDelete": @"Confirm Delete",
+            @"ConfirmDeleteProfile:%@": @"Are you sure you want to delete '%@'?",
+            @"DeleteTemplateNotAllowed:%@": @"Deleting template layout '%@' is not allowed",
+            @"UnnamedProfile": @"Untitled",
+            @"OK": @"OK",
+            @"Save": @"Save",
+            @"Cancel": @"Cancel",
+            @"CurrentLayoutShort": @"Current",
+            @"SelectLayoutToPair:%@": @"Select layout to pair: %@"
+        };
+    });
+    return [prefix isEqualToString:@"zh"] ? zhDict : enDict;
+}
+
 + (NSString *)localizedStringForKey:(NSString *)key, ... {
     va_list args;
     va_start(args, key);
 
     NSString *format = NSLocalizedStringFromTable(key, @"Localizable", nil);
+    if ([format isEqualToString:key]) { // not found in catalog, use fallback
+        NSString *lang = [self osc_languageCodePrefix];
+        NSString *fallback = [[self osc_fallbackDictionaryForLanguage:lang] objectForKey:key];
+        if (fallback) {
+            format = fallback;
+        }
+    }
     NSString *result = [[NSString alloc] initWithFormat:format arguments:args];
 
     va_end(args);

--- a/VoidLink/ViewControllers/CustomOSCViewControl/LayoutOnScreenControlsViewController.m
+++ b/VoidLink/ViewControllers/CustomOSCViewControl/LayoutOnScreenControlsViewController.m
@@ -1317,7 +1317,27 @@
     
     // _oscProfilesTableViewController.modalPresentationStyle = UIModalPresentationCurrentContext;
     _oscProfilesTableViewController.modalPresentationStyle = UIModalPresentationOverCurrentContext;
-    [self presentViewController:_oscProfilesTableViewController animated:YES completion:nil];
+
+    // 添加半透明黑色 overlay 到当前控制器视图之上
+    UIView *overlay = [[UIView alloc] initWithFrame:self.view.bounds];
+    overlay.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    overlay.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.3];
+    overlay.tag = 987654; // 识别用
+    [self.view addSubview:overlay];
+    [self.view bringSubviewToFront:overlay];
+
+    // 点击 overlay 关闭弹窗
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dismissProfilesByOverlayTap)];
+    [overlay addGestureRecognizer:tap];
+
+    // 监听移除 overlay 的通知
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(removeProfilesOverlay) name:@"OSCProfilesOverlayRemove" object:nil];
+
+    [self presentViewController:_oscProfilesTableViewController animated:YES completion:^{
+        // 确保 overlay 仍在最上面可点击
+        UIView *ov = [self.view viewWithTag:987654];
+        if (ov) [self.view bringSubviewToFront:ov];
+    }];
 }
 
 /* Presents the view controller that lists all OSC profiles the user can choose from */
@@ -1465,5 +1485,24 @@
     widgetPanelMovedByTouch = false;
 }
 
+// 点击 overlay 收起配置列表
+- (void)dismissProfilesByOverlayTap{
+    if (self->_oscProfilesTableViewController) {
+        [self->_oscProfilesTableViewController dismissViewControllerAnimated:YES completion:^{
+            [self removeProfilesOverlay];
+        }];
+    }
+    else {
+        [self removeProfilesOverlay];
+    }
+}
+
+- (void)removeProfilesOverlay{
+    UIView *overlay = [self.view viewWithTag:987654];
+    if (overlay) {
+        [overlay removeFromSuperview];
+    }
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"OSCProfilesOverlayRemove" object:nil];
+}
 
 @end

--- a/VoidLink/ViewControllers/CustomOSCViewControl/LayoutOnScreenControlsViewController.m
+++ b/VoidLink/ViewControllers/CustomOSCViewControl/LayoutOnScreenControlsViewController.m
@@ -265,6 +265,12 @@
                                                  name:UIDeviceOrientationDidChangeNotification
                                                object:nil];
     
+    // 监听StreamFrameViewController发送的屏幕变化通知
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleScreenChanged:)
+                                                 name:@"ScreenChanged"
+                                               object:nil];
+    
     OnScreenWidgetView.editMode = true;
     [self handleMissingToolBarIcon:toolbarRootView];
     [self profileRefresh];
@@ -294,18 +300,95 @@
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator{
-    if ([UIApplication sharedApplication].applicationState != UIApplicationStateActive) return;
+    NSLog(@"📱 viewWillTransitionToSize: %@ -> %@", NSStringFromCGSize(self.view.bounds.size), NSStringFromCGSize(size));
+    if ([UIApplication sharedApplication].applicationState != UIApplicationStateActive) {
+        NSLog(@"⚠️ 应用不在活跃状态，跳过旋转处理");
+        return;
+    }
     viewWillBeResized = true;
+    NSLog(@"✅ 设置 viewWillBeResized = true");
     [self hideStickIndicators];
     if(!_quickSwitchEnabled) [self saveTapped:nil];
 }
 
 - (void)deviceOrientationDidChange{
+    NSLog(@"📱 deviceOrientationDidChange 被调用");
     [self performSelector:@selector(handleOrientationChangeForOnScreenWidgets) withObject:self afterDelay:0.0];
 }
 
+- (void)handleScreenChanged:(NSNotification *)notification {
+    NSLog(@"📺 handleScreenChanged 被调用 - 来自StreamFrameViewController");
+    
+    // 只有在非布局编辑模式下才处理（即在串流界面中）
+    // 如果quickSwitchEnabled为true，说明是在布局列表页，应该跳过
+    if (self.quickSwitchEnabled) {
+        NSLog(@"⚠️ 布局编辑模式中，跳过handleScreenChanged");
+        return;
+    }
+    
+    // 在串流界面中，直接处理配对布局切换，不需要等待viewWillBeResized标志
+    [self handlePairedLayoutSwitching];
+}
+
+- (void)handlePairedLayoutSwitching {
+    NSLog(@"=== 配对布局切换处理开始 ===");
+    
+    // 如果是快速切换模式（布局列表页），跳过自动切换
+    if (self.quickSwitchEnabled) {
+        NSLog(@"⚠️ 快速切换模式中，跳过配对布局自动切换");
+        return;
+    }
+    
+    // 检查当前布局是否已配对，如果是则切换到配对布局
+    OSCProfile *currentProfile = [profilesManager getSelectedProfile];
+    NSLog(@"当前选中布局: %@", currentProfile ? currentProfile.name : @"无");
+    
+    if (currentProfile) {
+        NSLog(@"当前布局是否已配对: %@", currentProfile.isPaired ? @"是" : @"否");
+        NSLog(@"当前布局方向标记: %@ (isLandscapeLayout=%@)", 
+              currentProfile.isLandscapeLayout ? @"横屏" : @"竖屏",
+              currentProfile.isLandscapeLayout ? @"YES" : @"NO");
+        NSLog(@"配对的布局名称: %@", currentProfile.pairedProfileName ?: @"无");
+        
+        if (currentProfile.isPaired) {
+            BOOL isCurrentLandscape = [profilesManager isCurrentOrientationLandscape];
+            NSLog(@"当前实际屏幕方向: %@", isCurrentLandscape ? @"横屏" : @"竖屏");
+            
+            OSCProfile *targetProfile = [profilesManager getProfileForCurrentOrientation:currentProfile.name isLandscape:isCurrentLandscape];
+            NSLog(@"目标布局: %@", targetProfile ? targetProfile.name : @"无");
+            
+            if (targetProfile && ![targetProfile.name isEqualToString:currentProfile.name]) {
+                // 切换到配对的布局
+                NSLog(@"🔄 执行布局切换：从 %@ 切换到 %@", currentProfile.name, targetProfile.name);
+                [profilesManager setProfileToSelected:targetProfile.name];
+                NSLog(@"✅ 布局切换完成");
+                
+                // 重新加载布局
+                [self reloadLegacyOnScreenControls];
+                [self reloadOnScreenWidgetViews];
+            } else {
+                NSLog(@"❌ 不需要切换布局 - 目标布局与当前布局相同或目标布局为空");
+            }
+        } else {
+            NSLog(@"ℹ️ 当前布局未配对，使用自适应逻辑");
+        }
+    } else {
+        NSLog(@"❌ 没有选中的布局");
+    }
+    
+    NSLog(@"=== 配对布局切换处理结束 ===");
+}
+
 - (void)handleOrientationChangeForOnScreenWidgets{
-    if(!viewWillBeResized) return;
+    NSLog(@"🔄 handleOrientationChangeForOnScreenWidgets 被调用，viewWillBeResized = %@", viewWillBeResized ? @"YES" : @"NO");
+    if(!viewWillBeResized) {
+        NSLog(@"❌ viewWillBeResized = NO，跳过处理");
+        return;
+    }
+    
+    // 处理配对布局切换
+    [self handlePairedLayoutSwitching];
+    
     [self setupWidgetPanel];
     [self updateViewBounds];
 }
@@ -679,7 +762,9 @@
         if(sender) [self presentViewController:savedAlertController animated:YES completion:nil];
     }
     else{
-        UIAlertController * savedAlertController = [UIAlertController alertControllerWithTitle: [NSString stringWithFormat:@""] message: [LocalizationHelper localizedStringForKey:@"Profile Default can not be overwritten"] preferredStyle:UIAlertControllerStyleAlert];
+        OSCProfile *selectedProfile = [profilesManager getSelectedProfile];
+        NSString *message = [NSString stringWithFormat:@"模板布局'%@'不可被覆盖", selectedProfile.name];
+        UIAlertController * savedAlertController = [UIAlertController alertControllerWithTitle: [NSString stringWithFormat:@""] message: message preferredStyle:UIAlertControllerStyleAlert];
         [savedAlertController addAction:[UIAlertAction actionWithTitle:[LocalizationHelper localizedStringForKey:@"Ok"] style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
             [self.oscProfilesTableViewController profileViewRefresh]; // execute this will reset layout in OSC tool!
         }]];
@@ -1364,9 +1449,11 @@
     }
     [self.layoutOSC touchesEnded:touches withEvent:event];
     
-    // in case of default profile OSC change, popup msgbox & remind user it's not allowed.
-    if([profilesManager getIndexOfSelectedProfile] == 0 && [self.layoutOSC.layoutChanges count] > 0){
-        UIAlertController * movedAlertController = [UIAlertController alertControllerWithTitle: [NSString stringWithFormat:@""] message: [LocalizationHelper localizedStringForKey:@"Layout of the Default profile can not be changed"] preferredStyle:UIAlertControllerStyleAlert];
+    // 检查模板布局是否被修改，弹出提示
+    OSCProfile *currentProfile = [profilesManager getSelectedProfile];
+    if(currentProfile && [profilesManager isTemplateProfile:currentProfile.name] && [self.layoutOSC.layoutChanges count] > 0){
+        NSString *message = [NSString stringWithFormat:@"模板布局'%@'不可被修改", currentProfile.name];
+        UIAlertController * movedAlertController = [UIAlertController alertControllerWithTitle: [NSString stringWithFormat:@""] message: message preferredStyle:UIAlertControllerStyleAlert];
         [movedAlertController addAction:[UIAlertAction actionWithTitle:[LocalizationHelper localizedStringForKey:@"Ok"] style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
             [self.oscProfilesTableViewController profileViewRefresh];
         }]];

--- a/VoidLink/ViewControllers/CustomOSCViewControl/OSCProfilesTableViewController.h
+++ b/VoidLink/ViewControllers/CustomOSCViewControl/OSCProfilesTableViewController.h
@@ -33,6 +33,11 @@ typedef NS_ENUM(NSUInteger, FileOperation) {
 @property (nonatomic, assign) CGRect layoutViewBounds;
 @property (weak, nonatomic) IBOutlet UINavigationBar *profileTableViewNavigationBar;
 
+// 系统底部工具栏（Storyboard中新加的 UIToolbar）
+@property (weak, nonatomic) IBOutlet UIToolbar *systemBottomToolbar;
+@property (weak, nonatomic) IBOutlet UIBarButtonItem *pairRotationalToolbarItem; // “添加竖屏布局/解除配对”切换按钮
+@property (weak, nonatomic) IBOutlet UIBarButtonItem *helpToolbarItem;            // 右侧问号按钮（可选）
+
 // 配对相关UI组件
 @property (strong, nonatomic) UIView *bottomToolbarView;
 @property (strong, nonatomic) UIButton *pairingButton;

--- a/VoidLink/ViewControllers/CustomOSCViewControl/OSCProfilesTableViewController.h
+++ b/VoidLink/ViewControllers/CustomOSCViewControl/OSCProfilesTableViewController.h
@@ -33,6 +33,17 @@ typedef NS_ENUM(NSUInteger, FileOperation) {
 @property (nonatomic, assign) CGRect layoutViewBounds;
 @property (weak, nonatomic) IBOutlet UINavigationBar *profileTableViewNavigationBar;
 
+// 配对相关UI组件
+@property (strong, nonatomic) UIView *bottomToolbarView;
+@property (strong, nonatomic) UIButton *pairingButton;
+@property (strong, nonatomic) UIButton *saveButton;
+@property (strong, nonatomic) UIButton *cancelButton;
+
+// 配对状态
+@property (nonatomic, assign) BOOL isPairingMode;
+@property (nonatomic, strong) NSString *selectedProfileForPairing;
+@property (nonatomic, assign) BOOL isProcessingOrientationChange;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/VoidLink/ViewControllers/CustomOSCViewControl/OSCProfilesTableViewController.m
+++ b/VoidLink/ViewControllers/CustomOSCViewControl/OSCProfilesTableViewController.m
@@ -19,12 +19,15 @@
 
 const double NAV_BAR_HEIGHT = 50;
 
-@interface OSCProfilesTableViewController ()
+@interface OSCProfilesTableViewController () <UIGestureRecognizerDelegate>
 
 @end
 
 @implementation OSCProfilesTableViewController {
     OSCProfilesManager *profilesManager;
+    NSArray *storedLeftBarItems;
+    NSArray *storedRightBarItems;
+    NSString *storedNavTitle;
 }
 
 @synthesize tableView;
@@ -47,6 +50,11 @@ const double NAV_BAR_HEIGHT = 50;
     [super viewDidDisappear:animated];
 }
 
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"OSCProfilesOverlayRemove" object:nil];
+}
+
 
 - (void) viewDidLayoutSubviews {
     CGRect bounds = self.profileTableViewNavigationBar.bounds;
@@ -67,6 +75,17 @@ const double NAV_BAR_HEIGHT = 50;
     
     self.tableView.layer.cornerRadius = 15;  // 设置圆角半径
     self.tableView.layer.masksToBounds = true;  // 使圆角生效
+
+    // 恢复底部系统 UIToolbar 的圆角（下边两个角）
+    if (self.systemBottomToolbar) {
+        self.systemBottomToolbar.clipsToBounds = YES;
+        self.systemBottomToolbar.layer.cornerRadius = 15;
+#ifdef __IPHONE_11_0
+        if ([self.systemBottomToolbar.layer respondsToSelector:@selector(setMaskedCorners:)]) {
+            self.systemBottomToolbar.layer.maskedCorners = kCALayerMinXMaxYCorner | kCALayerMaxXMaxYCorner;
+        }
+#endif
+    }
 }
 
 - (void) viewDidLoad {
@@ -83,22 +102,51 @@ const double NAV_BAR_HEIGHT = 50;
     
     [self.tableView registerNib:[UINib nibWithNibName:@"ProfileTableViewCell" bundle:nil]
          forCellReuseIdentifier:@"Cell"]; // Register the custom cell nib file with the table view
-    self.tableView.alpha = 0.7;
-    //self.tableView.backgroundColor = [[UIColor colorWithRed:0.5 green:0.7 blue:1.0 alpha:1.0] colorWithAlphaComponent:0.2]; // set background color & transparency
-    self.tableView.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.5]; // set background color & transparency
-    // self.tableView.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.2]; // set background color & transparency
+    self.view.backgroundColor = [UIColor clearColor];
+    self.tableView.alpha = 1.0;
+    // 列表主体使用白色 95% 透明背景
+    self.tableView.backgroundColor = [[UIColor whiteColor] colorWithAlphaComponent:0.95];
+    // 顶部文字按钮统一使用青色
+    if (self.navigationController) {
+        self.navigationController.navigationBar.tintColor = [UIColor systemTealColor];
+        // 移除顶部工具栏透明度
+        self.navigationController.navigationBar.translucent = NO;
+        self.navigationController.navigationBar.barTintColor = [UIColor whiteColor];
+    }
+    if (self.profileTableViewNavigationBar) {
+        self.profileTableViewNavigationBar.tintColor = [UIColor systemTealColor];
+        self.profileTableViewNavigationBar.translucent = NO;
+        self.profileTableViewNavigationBar.barTintColor = [UIColor whiteColor];
+    }
+    
+    // 移除系统自带分隔线，避免与自定义分隔线叠加
+    self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
 
+    // 添加点击背景关闭的手势（仅在点击 tableView 以外区域时生效）
+    UITapGestureRecognizer *bgTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleBackgroundTap:)];
+    bgTap.cancelsTouchesInView = NO;
+    bgTap.delegate = self;
+    [self.view addGestureRecognizer:bgTap];
+    
     // 初始化配对状态
     self.isPairingMode = NO;
     self.selectedProfileForPairing = nil;
     self.isProcessingOrientationChange = NO;
     
-    // 设置底部工具栏
-    [self setupBottomToolbar];
+    // 设置底部工具栏（自定义bar 与 系统UIToolbar 二选一，系统UIToolbar优先）
+    if (self.systemBottomToolbar) {
+        // 系统 Toolbar 存在：优先使用系统 Toolbar
+        [self updateSystemToolbarItems];
+    } else {
+        // 兼容旧版自定义工具栏
+        [self setupBottomToolbar];
+    }
     
-    // 调整tableView的底部边距，为工具栏留出空间
-    self.tableView.contentInset = UIEdgeInsetsMake(0, 0, 80, 0);  // 50(工具栏高度) + 16(底部间距) + 16(额外间距)
-    self.tableView.scrollIndicatorInsets = UIEdgeInsetsMake(0, 0, 80, 0);
+    // 调整tableView的底部边距，为工具栏留出空间（系统或自定义）
+    CGFloat tbHeight = self.systemBottomToolbar ? self.systemBottomToolbar.bounds.size.height : 50.0;
+    CGFloat bottomInset = MAX(64.0, tbHeight + 30.0);
+    self.tableView.contentInset = UIEdgeInsetsMake(0, 0, bottomInset, 0);
+    self.tableView.scrollIndicatorInsets = UIEdgeInsetsMake(0, 0, bottomInset, 0);
     
     // 监听设备方向变化
     [[NSNotificationCenter defaultCenter] addObserver:self
@@ -128,6 +176,9 @@ const double NAV_BAR_HEIGHT = 50;
      
      // 更新工具栏按钮状态
      [self updateToolbarButtons];
+    if (self.systemBottomToolbar) {
+        [self updateSystemToolbarItems];
+    }
 }
 
 
@@ -228,11 +279,11 @@ const double NAV_BAR_HEIGHT = 50;
     }
     
     // 删除确认弹窗
-    NSString *confirmMessage = [NSString stringWithFormat:@"确定要删除布局'%@'吗？", currentProfile.name];
-    UIAlertController *confirmController = [UIAlertController alertControllerWithTitle:@"确认删除" message:confirmMessage preferredStyle:UIAlertControllerStyleAlert];
+    NSString *confirmMessage = [LocalizationHelper localizedStringForKey:@"ConfirmDeleteProfile:%@", currentProfile.name];
+    UIAlertController *confirmController = [UIAlertController alertControllerWithTitle:[LocalizationHelper localizedStringForKey:@"ConfirmDelete"] message:confirmMessage preferredStyle:UIAlertControllerStyleAlert];
     
-    [confirmController addAction:[UIAlertAction actionWithTitle:@"取消" style:UIAlertActionStyleCancel handler:nil]];
-    [confirmController addAction:[UIAlertAction actionWithTitle:@"删除" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
+    [confirmController addAction:[UIAlertAction actionWithTitle:[LocalizationHelper localizedStringForKey:@"Cancel"] style:UIAlertActionStyleCancel handler:nil]];
+    [confirmController addAction:[UIAlertAction actionWithTitle:[LocalizationHelper localizedStringForKey:@"Delete"] style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
         [self->profilesManager deleteCurrentSelectedProfile];
         [self profileViewRefresh];
     }]];
@@ -370,79 +421,161 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
         return cell;
     }
     
-    // 构建显示文本，包含配对标识和模板标识
-    NSString *displayText = profile.name ?: @"未命名配置";  // 防止name为nil
-    
-    // 添加模板标识
-    if ([profilesManager isTemplateProfile:profile.name]) {
-        displayText = [NSString stringWithFormat:@"📋 %@", displayText];
-    }
-    
-    // 添加配对标识
-    if (profile.isPaired) {
-        NSString *orientationText = [self getOrientationDisplayText:profile.isLandscapeLayout];
-        displayText = [NSString stringWithFormat:@"%@ %@", orientationText, displayText];
-    }
-    
-    cell.name.text = displayText;
-    cell.name.backgroundColor = [UIColor clearColor];
-    cell.name.alpha = 1.0;
-    
-    // 根据配对模式设置文本颜色和可选择性
+    // 名称 + 可选“横屏/竖屏”胶囊
+    NSString *baseName = profile.name ?: @"未命名配置";  // 防止name为nil
+
+    // 模板布局不再添加 emoji
+
+    // 配对模式下的可选性与配色
     BOOL canSelect = [self canSelectProfileForPairing:profile];
-    if (self.isPairingMode && !canSelect) {
-        cell.name.textColor = [UIColor grayColor];  // 不可选择的布局显示为灰色
-        cell.userInteractionEnabled = NO;
+    BOOL isCurrentSelectedProfileRow = [[[profilesManager getSelectedProfile] name] isEqualToString:profile.name];
+    BOOL isPairSelectionRow = (self.isPairingMode && self.selectedProfileForPairing && [self.selectedProfileForPairing isEqualToString:profile.name]);
+    UIColor *nameColor = [UIColor blackColor];
+    if (self.isPairingMode) {
+        if (isPairSelectionRow) {
+            // 选中的配对目标：teal
+            nameColor = [UIColor systemTealColor];
+            cell.userInteractionEnabled = YES;
+            cell.contentView.alpha = 1.0;
+        } else if (isCurrentSelectedProfileRow) {
+            // 当前正在使用的布局：文字 teal，整体不降透明度
+            nameColor = [UIColor systemTealColor];
+            cell.userInteractionEnabled = NO;
+            cell.contentView.alpha = 1.0;
+        } else if (!canSelect) {
+            // 其它不可选：灰
+            nameColor = [UIColor colorWithWhite:0 alpha:0.3];
+            cell.userInteractionEnabled = NO;
+            cell.contentView.alpha = 0.7; // 整体降低 30% 透明度
+        } else {
+            nameColor = [UIColor blackColor];
+            cell.userInteractionEnabled = YES;
+            cell.contentView.alpha = 1.0;
+        }
     } else {
-        cell.name.textColor = [UIColor whiteColor];  // 正常白色文本
+        nameColor = isCurrentSelectedProfileRow ? [UIColor systemTealColor] : [UIColor blackColor];
         cell.userInteractionEnabled = YES;
+        cell.contentView.alpha = 1.0;
     }
-    
-    cell.name.font =[UIFont systemFontOfSize:20 weight:UIFontWeightMedium];
-    cell.name.shadowColor = [UIColor blackColor];  // Black shadow
-    // Set the shadow offset
-    cell.name.shadowOffset = CGSizeMake(1.0, 1.5);
+
+    UIFont *nameFont = [UIFont systemFontOfSize:20 weight:UIFontWeightMedium];
+    NSMutableAttributedString *line = [[NSMutableAttributedString alloc] initWithString:baseName attributes:@{NSFontAttributeName:nameFont, NSForegroundColorAttributeName:nameColor}];
+     
+     if (profile.isPaired) {
+         // 4pt 间距
+         NSAttributedString *space = [[NSAttributedString alloc] initWithString:@" " attributes:@{NSKernAttributeName:@(4)}];
+         [line appendAttributedString:space];
+         
+         NSString *pillText = profile.isLandscapeLayout ? @"横屏" : @"竖屏";
+         BOOL pillDisabled = (self.isPairingMode && (!canSelect || isCurrentSelectedProfileRow));
+         BOOL pillSelected = self.isPairingMode ? isPairSelectionRow : isCurrentSelectedProfileRow;
+         UIImage *pill = [self osc_makeOrientationPill:pillText selected:pillSelected disabled:pillDisabled];
+         if (pill) {
+             NSTextAttachment *att = [[NSTextAttachment alloc] init];
+             att.image = pill;
+             att.bounds = CGRectMake(0, -2, pill.size.width, pill.size.height);
+             [line appendAttributedString:[NSAttributedString attributedStringWithAttachment:att]];
+         }
+     }
+     
+     cell.name.attributedText = line;
+     cell.name.backgroundColor = [UIColor clearColor];
+     cell.name.alpha = 1.0;
+     cell.name.font = nameFont;
+     // 去掉阴影
+     cell.name.shadowColor = nil;
+     cell.name.shadowOffset = CGSizeZero;
 
     // Set cell and contentView background colors
-    cell.backgroundColor = [UIColor clearColor];
+    BOOL isCurrentRowInPairingMode = (self.isPairingMode && isCurrentSelectedProfileRow);
+    cell.backgroundColor = isCurrentRowInPairingMode ? [[UIColor systemTealColor] colorWithAlphaComponent:0.08] : [UIColor clearColor];
     cell.contentView.backgroundColor = [UIColor clearColor];
+
+    // 在配对模式下为“当前布局”行右侧添加 14pt 小字
+    UILabel *currentBadge = (UILabel *)[cell viewWithTag:201];
+    if (isCurrentRowInPairingMode) {
+        if (!currentBadge) {
+            currentBadge = [[UILabel alloc] init];
+            currentBadge.tag = 201;
+            currentBadge.font = [UIFont systemFontOfSize:14 weight:UIFontWeightRegular];
+            currentBadge.textColor = [[UIColor blackColor] colorWithAlphaComponent:0.3];
+            currentBadge.textAlignment = NSTextAlignmentRight;
+            currentBadge.backgroundColor = [UIColor clearColor];
+            currentBadge.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
+            [cell addSubview:currentBadge];
+        }
+        currentBadge.hidden = NO;
+        currentBadge.text = [LocalizationHelper localizedStringForKey:@"CurrentLayoutShort"];
+        currentBadge.textColor = [[UIColor systemTealColor] colorWithAlphaComponent:0.9];
+        CGSize txt = [currentBadge.text sizeWithAttributes:@{NSFontAttributeName: currentBadge.font}];
+        CGFloat paddingRight = 16.0;
+        CGFloat x = cell.bounds.size.width - paddingRight - txt.width;
+        CGFloat y = floor((cell.bounds.size.height - txt.height) * 0.5);
+        currentBadge.frame = CGRectMake(x, y, txt.width, txt.height);
+    } else if (currentBadge) {
+        currentBadge.hidden = YES;
+    }
     
     // Configure the checkmark accessory
-    if ([profile.name isEqualToString:[profilesManager getSelectedProfile].name]) {
-        cell.accessoryType = UITableViewCellAccessoryCheckmark;
-    } else {
+    if (self.isPairingMode) {
+        // 配对模式：隐藏当前使用布局的小勾；仅对选中的配对目标显示小勾
         cell.accessoryType = UITableViewCellAccessoryNone;
+    } else {
+        if (isCurrentSelectedProfileRow) {
+            cell.accessoryType = UITableViewCellAccessoryCheckmark;
+        } else {
+            cell.accessoryType = UITableViewCellAccessoryNone;
+        }
     }
     
     // Remove existing custom separators to avoid duplicates
-    UIView *existingSeparator = [cell.contentView viewWithTag:100];
+    UIView *existingSeparator = [cell viewWithTag:100];
     if (existingSeparator) {
         [existingSeparator removeFromSuperview];
     }
 
     // Add custom separator with increased height (thickness)
     CGFloat separatorHeight = 1.0; // Adjust this value for thicker line
-    UIView *separatorView = [[UIView alloc] initWithFrame:CGRectMake(0, cell.contentView.frame.size.height - separatorHeight, cell.contentView.frame.size.width, separatorHeight)];
+    // 使用 cell 的宽度，确保分隔线在 accessory 区域下方也能显示完整
+    UIView *separatorView = [[UIView alloc] initWithFrame:CGRectMake(0, cell.bounds.size.height - separatorHeight, cell.bounds.size.width, separatorHeight)];
     
-    separatorView.backgroundColor = [UIColor whiteColor];  // Set your desired color
+    // 分隔线：黑色 12% 透明度
+    separatorView.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.12];
     separatorView.tag = 100;  // Assign a tag to identify the separator view
     separatorView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin;
 
-    [cell.contentView addSubview:separatorView];
-    [cell.contentView bringSubviewToFront:separatorView];
+    // 加到 cell 上以避免 contentView 宽度被 accessory 缩短导致分隔线变短
+    [cell addSubview:separatorView];
+    [cell bringSubviewToFront:separatorView];
 
 
     // Replace the default checkmark with a UILabel displaying a checkmark character
-    if ([profile.name isEqualToString:[profilesManager getSelectedProfile].name]) {
-        UILabel *checkmarkLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 20, 20)]; // Adjust size as needed
-        checkmarkLabel.text = @"✓";  // The checkmark character
-        checkmarkLabel.font = [UIFont systemFontOfSize:25]; // Adjust font size as needed
-        checkmarkLabel.textAlignment = NSTextAlignmentCenter;
-        checkmarkLabel.textColor = [UIColor greenColor];  // Set the color of the checkmark
-        cell.accessoryView = checkmarkLabel;
-        checkmarkLabel.layer.zPosition = 0; // Push checkmark to the back
+    if (self.isPairingMode) {
+        if (isPairSelectionRow) {
+            UILabel *checkmarkLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 20, 20)];
+            checkmarkLabel.text = @"✓";
+            checkmarkLabel.font = [UIFont systemFontOfSize:25];
+            checkmarkLabel.textAlignment = NSTextAlignmentCenter;
+            checkmarkLabel.textColor = [UIColor systemTealColor];
+            cell.accessoryView = checkmarkLabel;
+            checkmarkLabel.layer.zPosition = 0;
+        } else {
+            cell.accessoryView = nil;
+        }
+        // 当前布局：强制隐藏系统默认 accessoryType
+        cell.accessoryType = UITableViewCellAccessoryNone;
     } else {
-        cell.accessoryView = nil;  // Remove checkmark if not selected
+        if (isCurrentSelectedProfileRow) {
+            UILabel *checkmarkLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 20, 20)];
+            checkmarkLabel.text = @"✓";
+            checkmarkLabel.font = [UIFont systemFontOfSize:25];
+            checkmarkLabel.textAlignment = NSTextAlignmentCenter;
+            checkmarkLabel.textColor = [UIColor systemTealColor];
+            cell.accessoryView = checkmarkLabel;
+            checkmarkLabel.layer.zPosition = 0;
+        } else {
+            cell.accessoryView = nil;
+        }
     }
     [cell.contentView bringSubviewToFront:separatorView];
     separatorView.layer.zPosition = 1; // Bring separator to the top layer
@@ -491,7 +624,7 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
         
         // 检查是否为模板布局
         if ([profilesManager isTemplateProfile:profileToDelete.name]) {
-            NSString *message = [NSString stringWithFormat:@"删除'%@'模板布局是不被允许的", profileToDelete.name];
+            NSString *message = [LocalizationHelper localizedStringForKey:@"DeleteTemplateNotAllowed:%@", profileToDelete.name];
             UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"" message:message preferredStyle:UIAlertControllerStyleAlert];
             
             [alertController addAction:[UIAlertAction actionWithTitle:[LocalizationHelper localizedStringForKey:@"Ok"] style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
@@ -502,11 +635,11 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
         }
         
         // 删除确认弹窗
-        NSString *confirmMessage = [NSString stringWithFormat:@"确定要删除布局'%@'吗？", profileToDelete.name];
-        UIAlertController *confirmController = [UIAlertController alertControllerWithTitle:@"确认删除" message:confirmMessage preferredStyle:UIAlertControllerStyleAlert];
+        NSString *confirmMessage = [LocalizationHelper localizedStringForKey:@"ConfirmDeleteProfile:%@", profileToDelete.name];
+        UIAlertController *confirmController = [UIAlertController alertControllerWithTitle:[LocalizationHelper localizedStringForKey:@"ConfirmDelete"] message:confirmMessage preferredStyle:UIAlertControllerStyleAlert];
         
-        [confirmController addAction:[UIAlertAction actionWithTitle:@"取消" style:UIAlertActionStyleCancel handler:nil]];
-        [confirmController addAction:[UIAlertAction actionWithTitle:@"删除" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
+        [confirmController addAction:[UIAlertAction actionWithTitle:[LocalizationHelper localizedStringForKey:@"Cancel"] style:UIAlertActionStyleCancel handler:nil]];
+        [confirmController addAction:[UIAlertAction actionWithTitle:[LocalizationHelper localizedStringForKey:@"Delete"] style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
             [self performDeleteProfile:profileToDelete atIndexPath:indexPath];
         }]];
         
@@ -577,6 +710,17 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
         if ([self canSelectProfileForPairing:profile]) {
             self.selectedProfileForPairing = profile.name;
             [self updateToolbarButtons];  // 更新保存按钮状态
+            if (self.systemBottomToolbar) {
+                [self updateSystemToolbarItems];
+            }
+            // 刷新整表以更新：
+            // 1) 选中配对目标行（小勾 + teal）
+            // 2) 当前使用的布局行（隐藏小勾 + 30% 黑）
+            // 3) 不可选项（变灰）
+            [self.tableView reloadData];
+            // 滚动确保选中项可见
+            NSIndexPath *visible = [NSIndexPath indexPathForRow:indexPath.row inSection:0];
+            [self.tableView scrollToRowAtIndexPath:visible atScrollPosition:UITableViewScrollPositionMiddle animated:YES];
         }
         [tableView deselectRowAtIndexPath:indexPath animated:YES];
         return;
@@ -601,8 +745,9 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
         
         /* Place checkmark on selected cell and set profile associated with cell as selected profile */
         UITableViewCell *selectedCell = [tableView cellForRowAtIndexPath: selectedIndexPath];
-        selectedCell.accessoryType = UITableViewCellAccessoryCheckmark;  // add checkmark to the cell the user tapped
-        selectedCell.accessoryView.tintColor = [[UIColor colorWithRed:0.5 green:0.5 blue:1.0 alpha:0.85] colorWithAlphaComponent:1.0];
+        selectedCell.accessoryType = UITableViewCellAccessoryCheckmark;
+        // 选中时的勾颜色统一为青色
+        selectedCell.accessoryView.tintColor = [UIColor systemTealColor];
         [profilesManager setProfileToSelected: profile.name];   // set the profile associated with this cell's 'isSelected' property to YES
         
         /* Remove checkmark on the previously selected cell  */
@@ -669,6 +814,11 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
 }
 
 - (void)updateToolbarButtons {
+    // 系统 UIToolbar 优先：如果 storyboard 连接了系统 toolbar，则同步系统 toolbar
+    if (self.systemBottomToolbar) {
+        [self updateSystemToolbarItems];
+        return;
+    }
     // 如果工具栏不存在，直接返回
     if (!self.bottomToolbarView) {
         return;
@@ -710,10 +860,106 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
     }
 }
 
+#pragma mark - System UIToolbar Support
+
+- (void)updateSystemToolbarItems {
+    if (!self.systemBottomToolbar || !self.pairRotationalToolbarItem) {
+        return;
+    }
+
+    OSCProfile *selectedProfile = [profilesManager getSelectedProfile];
+    BOOL isTemplate = selectedProfile && [profilesManager isTemplateProfile:selectedProfile.name];
+    BOOL isCurrentProfilePaired = selectedProfile ? selectedProfile.isPaired : NO;
+    BOOL isLandscape = [profilesManager isCurrentOrientationLandscape];
+
+    if (self.isPairingMode) {
+        // 配对模式：主按钮=保存；右侧问号=取消
+        self.pairRotationalToolbarItem.title = [LocalizationHelper localizedStringForKey:@"Save"];
+        self.pairRotationalToolbarItem.enabled = (self.selectedProfileForPairing != nil);
+        self.pairRotationalToolbarItem.target = self;
+        self.pairRotationalToolbarItem.action = @selector(savePairingTapped:);
+        if (self.helpToolbarItem) {
+            self.helpToolbarItem.title = [LocalizationHelper localizedStringForKey:@"Cancel"];
+            self.helpToolbarItem.image = nil;
+            self.helpToolbarItem.target = self;
+            self.helpToolbarItem.action = @selector(cancelPairingTapped:);
+            self.helpToolbarItem.enabled = YES;
+        }
+        // 强制保持 items 排列：flexibleSpace + pair + help
+        UIBarButtonItem *flex = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
+        if (self.helpToolbarItem) {
+            [self.systemBottomToolbar setItems:@[flex, self.pairRotationalToolbarItem, self.helpToolbarItem] animated:NO];
+        }
+        return;
+    }
+
+    // 普通模式
+    self.pairRotationalToolbarItem.enabled = !isTemplate;
+    self.pairRotationalToolbarItem.target = self;
+    self.pairRotationalToolbarItem.action = @selector(pairRotationalToolbarTapped:);
+
+    if (isTemplate) {
+        NSString *opposite = isLandscape ? [LocalizationHelper localizedStringForKey:@"PortraitShort"] : [LocalizationHelper localizedStringForKey:@"LandscapeShort"];
+        self.pairRotationalToolbarItem.title = [LocalizationHelper localizedStringForKey:@"BindOrientationLayout:%@", opposite];
+        self.pairRotationalToolbarItem.enabled = NO;
+    } else if (isCurrentProfilePaired) {
+        self.pairRotationalToolbarItem.title = [LocalizationHelper localizedStringForKey:@"Unpair"];
+    } else {
+        NSString *opposite = isLandscape ? [LocalizationHelper localizedStringForKey:@"PortraitShort"] : [LocalizationHelper localizedStringForKey:@"LandscapeShort"];
+        self.pairRotationalToolbarItem.title = [LocalizationHelper localizedStringForKey:@"BindOrientationLayout:%@", opposite];
+    }
+
+    if (self.helpToolbarItem) {
+        // 正常模式：问号作为“帮助”，点击弹出说明
+        self.helpToolbarItem.title = nil; // 保持问号图标
+        // 退出配对模式后恢复问号图标
+        #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+        if (@available(iOS 13.0, *)) {
+            self.helpToolbarItem.image = [UIImage systemImageNamed:@"questionmark.circle"];
+        }
+        #endif
+        self.helpToolbarItem.target = self;
+        self.helpToolbarItem.action = @selector(helpToolbarTapped:);
+        self.helpToolbarItem.enabled = !isTemplate; // 模板布局置灰
+    }
+
+    // 强制保持 items 排列：flexibleSpace + pair + help
+    UIBarButtonItem *flex = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
+    if (self.helpToolbarItem) {
+        [self.systemBottomToolbar setItems:@[flex, self.pairRotationalToolbarItem, self.helpToolbarItem] animated:NO];
+    }
+}
+
+- (IBAction)pairRotationalToolbarTapped:(id)sender {
+    if (self.isPairingMode) {
+        if (self.selectedProfileForPairing) {
+            [self savePairingTapped:sender];
+        } else {
+            [self cancelPairingTapped:sender];
+        }
+        return;
+    }
+
+    OSCProfile *selectedProfile = [profilesManager getSelectedProfile];
+    if (selectedProfile && selectedProfile.isPaired) {
+        [self unpairTapped:sender];
+    } else {
+        [self startPairingTapped:sender];
+    }
+    [self updateSystemToolbarItems];
+}
+
+- (IBAction)helpToolbarTapped:(id)sender {
+    NSString *message = [LocalizationHelper localizedStringForKey:@"PairingHelpMessage"];
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:[LocalizationHelper localizedStringForKey:@"PairingHelpTitle"] message:message preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:[LocalizationHelper localizedStringForKey:@"OK"] style:UIAlertActionStyleDefault handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
 - (void)createPairingModeButtons {
     // 创建取消按钮
     self.cancelButton = [UIButton buttonWithType:UIButtonTypeSystem];
-    [self.cancelButton setTitle:@"取消" forState:UIControlStateNormal];
+    [self.cancelButton setTitle:[LocalizationHelper localizedStringForKey:@"Cancel"] forState:UIControlStateNormal];
     [self.cancelButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
     [self.cancelButton addTarget:self action:@selector(cancelPairingTapped:) forControlEvents:UIControlEventTouchUpInside];
     self.cancelButton.translatesAutoresizingMaskIntoConstraints = NO;
@@ -721,7 +967,7 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
     
     // 创建保存按钮
     self.saveButton = [UIButton buttonWithType:UIButtonTypeSystem];
-    [self.saveButton setTitle:@"保存" forState:UIControlStateNormal];
+    [self.saveButton setTitle:[LocalizationHelper localizedStringForKey:@"Save"] forState:UIControlStateNormal];
     [self.saveButton setTitleColor:[UIColor systemBlueColor] forState:UIControlStateNormal];
     [self.saveButton setTitleColor:[UIColor grayColor] forState:UIControlStateDisabled];
     [self.saveButton addTarget:self action:@selector(savePairingTapped:) forControlEvents:UIControlEventTouchUpInside];
@@ -763,6 +1009,21 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
     self.isPairingMode = YES;
     self.selectedProfileForPairing = nil;
     [self updateToolbarButtons];
+    if (self.systemBottomToolbar) {
+        [self updateSystemToolbarItems];
+    }
+    // 隐藏顶部导航按钮并设置标题
+    UINavigationItem *navItem = self.navigationController ? self.navigationController.navigationBar.topItem : self.profileTableViewNavigationBar.topItem;
+    if (navItem) {
+        storedLeftBarItems = navItem.leftBarButtonItems;
+        storedRightBarItems = navItem.rightBarButtonItems;
+        storedNavTitle = navItem.title;
+        navItem.leftBarButtonItems = @[];
+        navItem.rightBarButtonItems = @[];
+        BOOL isLandscape = [profilesManager isCurrentOrientationLandscape];
+        NSString *dir = isLandscape ? [LocalizationHelper localizedStringForKey:@"LandscapeShort"] : [LocalizationHelper localizedStringForKey:@"PortraitShort"];
+        navItem.title = [LocalizationHelper localizedStringForKey:@"SelectLayoutToPair:%@", dir];
+    }
     [self.tableView reloadData];
 }
 
@@ -771,6 +1032,9 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
     if (selectedProfile && selectedProfile.isPaired) {
         [profilesManager unpairProfile:selectedProfile.name];
         [self updateToolbarButtons];
+        if (self.systemBottomToolbar) {
+            [self updateSystemToolbarItems];
+        }
         [self.tableView reloadData];
     }
 }
@@ -793,6 +1057,16 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
             self.isPairingMode = NO;
             self.selectedProfileForPairing = nil;
             [self updateToolbarButtons];
+            if (self.systemBottomToolbar) {
+                [self updateSystemToolbarItems];
+            }
+            // 恢复导航按钮和标题
+            UINavigationItem *navItem = self.navigationController ? self.navigationController.navigationBar.topItem : self.profileTableViewNavigationBar.topItem;
+            if (navItem) {
+                navItem.leftBarButtonItems = storedLeftBarItems;
+                navItem.rightBarButtonItems = storedRightBarItems;
+                navItem.title = storedNavTitle;
+            }
             [self.tableView reloadData];
         } else {
             NSLog(@"配对失败");
@@ -804,6 +1078,16 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
     self.isPairingMode = NO;
     self.selectedProfileForPairing = nil;
     [self updateToolbarButtons];
+    if (self.systemBottomToolbar) {
+        [self updateSystemToolbarItems];
+    }
+    // 恢复导航按钮和标题
+    UINavigationItem *navItem = self.navigationController ? self.navigationController.navigationBar.topItem : self.profileTableViewNavigationBar.topItem;
+    if (navItem) {
+        navItem.leftBarButtonItems = storedLeftBarItems;
+        navItem.rightBarButtonItems = storedRightBarItems;
+        navItem.title = storedNavTitle;
+    }
     [self.tableView reloadData];
 }
 
@@ -988,6 +1272,61 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
         // 递归搜索子视图
         [self findAndUpdateDeleteButtonInView:subview isTemplate:isTemplate];
     }
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
+    // 仅当点击在 tableView 之外时，才触发手势
+    CGPoint p = [touch locationInView:self.view];
+    if (CGRectContainsPoint(self.tableView.frame, p)) {
+        return NO;
+    }
+    return YES;
+}
+
+- (void)handleBackgroundTap:(UITapGestureRecognizer *)gr {
+    if (gr.state == UIGestureRecognizerStateEnded) {
+        [self dismissViewControllerAnimated:YES completion:nil];
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"OSCProfilesOverlayRemove" object:nil];
+    }
+}
+
+// 绘制“横屏/竖屏”胶囊
+- (UIImage *)osc_makeOrientationPill:(NSString *)text selected:(BOOL)selected disabled:(BOOL)disabled {
+    const CGFloat pillHeight = 18.0; // 调整为 18pt 高
+    const CGFloat cornerRadius = 3.0;
+    const CGFloat horizontalPadding = 4.0; // 左右各 4pt
+    UIFont *font = [UIFont systemFontOfSize:13.0 weight:UIFontWeightRegular]; // 字号 13pt
+    UIColor *teal = [UIColor systemTealColor];
+    UIColor *fillColor;
+    UIColor *textColor;
+    if (disabled) {
+        fillColor = [[UIColor blackColor] colorWithAlphaComponent:0.08];
+        textColor = [[UIColor blackColor] colorWithAlphaComponent:0.3];
+    } else {
+        fillColor = selected ? [teal colorWithAlphaComponent:0.12] : [[UIColor blackColor] colorWithAlphaComponent:0.12];
+        textColor = selected ? [teal colorWithAlphaComponent:0.8] : [[UIColor blackColor] colorWithAlphaComponent:0.8];
+    }
+
+    NSDictionary *attrs = @{ NSFontAttributeName: font, NSForegroundColorAttributeName: textColor };
+    CGSize textSize = [text sizeWithAttributes:attrs];
+    CGFloat pillWidth = ceil(textSize.width) + horizontalPadding * 2.0;
+    CGSize canvas = CGSizeMake(pillWidth, pillHeight);
+
+    UIGraphicsBeginImageContextWithOptions(canvas, NO, 0);
+    CGContextRef ctx = UIGraphicsGetCurrentContext();
+    if (ctx) {
+        UIBezierPath *path = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(0, 0, canvas.width, canvas.height) cornerRadius:cornerRadius];
+        [fillColor setFill];
+        [path fill];
+        
+        // 居中绘制文字
+        CGFloat tx = horizontalPadding;
+        CGFloat ty = floor((pillHeight - textSize.height) * 0.5);
+        [text drawAtPoint:CGPointMake(tx, ty) withAttributes:attrs];
+    }
+    UIImage *img = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return img;
 }
 
 @end

--- a/VoidLink/ViewControllers/CustomOSCViewControl/OSCProfilesTableViewController.m
+++ b/VoidLink/ViewControllers/CustomOSCViewControl/OSCProfilesTableViewController.m
@@ -88,6 +88,26 @@ const double NAV_BAR_HEIGHT = 50;
     self.tableView.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.5]; // set background color & transparency
     // self.tableView.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.2]; // set background color & transparency
 
+    // 初始化配对状态
+    self.isPairingMode = NO;
+    self.selectedProfileForPairing = nil;
+    self.isProcessingOrientationChange = NO;
+    
+    // 设置底部工具栏
+    [self setupBottomToolbar];
+    
+    // 调整tableView的底部边距，为工具栏留出空间
+    self.tableView.contentInset = UIEdgeInsetsMake(0, 0, 80, 0);  // 50(工具栏高度) + 16(底部间距) + 16(额外间距)
+    self.tableView.scrollIndicatorInsets = UIEdgeInsetsMake(0, 0, 80, 0);
+    
+    // 监听设备方向变化
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(deviceOrientationDidChange:)
+                                                 name:UIDeviceOrientationDidChangeNotification
+                                               object:nil];
+    
+    // 初始更新删除按钮状态
+    [self updateDeleteButtonState];
 }
 
 - (void) viewDidAppear:(BOOL)animated {
@@ -105,6 +125,9 @@ const double NAV_BAR_HEIGHT = 50;
         NSIndexPath *indexPath = [NSIndexPath indexPathForRow:[profilesManager getIndexOfSelectedProfile] inSection:0];
         [self.tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionMiddle animated:YES];
      }
+     
+     // 更新工具栏按钮状态
+     [self updateToolbarButtons];
 }
 
 
@@ -128,8 +151,9 @@ const double NAV_BAR_HEIGHT = 50;
             UITextField *nameField = textFields[0];
             NSString *enteredProfileName = nameField.text;
             
-            if ([enteredProfileName isEqualToString:@"Default"]) {  // don't let user user overwrite the 'Default' profile
-                UIAlertController *alertController = [UIAlertController alertControllerWithTitle: [NSString stringWithFormat:@""] message: [LocalizationHelper localizedStringForKey:@"Saving over the 'Default' profile is not allowed"] preferredStyle:UIAlertControllerStyleAlert];
+            if ([profilesManager isTemplateProfile:enteredProfileName]) {  // 不允许覆盖模板布局
+                NSString *message = [NSString stringWithFormat:@"不允许覆盖模板布局'%@'", enteredProfileName];
+                UIAlertController *alertController = [UIAlertController alertControllerWithTitle: [NSString stringWithFormat:@""] message: message preferredStyle:UIAlertControllerStyleAlert];
                 
                 [alertController addAction:[UIAlertAction actionWithTitle:[LocalizationHelper localizedStringForKey:@"Ok"] style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
                     [alertController dismissViewControllerAnimated:NO completion:^{
@@ -180,15 +204,40 @@ const double NAV_BAR_HEIGHT = 50;
     //[self dismissViewControllerAnimated:YES completion:nil];
     //[selfparentLayoutOSCViewController]
     [self.tableView reloadData]; // table view will be refreshed by calling reloadData
+    [self updateDeleteButtonState]; // 更新顶部删除按钮状态
     if (self.needToUpdateOscLayoutTVC) {    // tells the presenting view controller to lay out the on screen buttons according to the selected profile's instructions
         self.needToUpdateOscLayoutTVC();
     }
     [[NSNotificationCenter defaultCenter] postNotificationName:@"OscLayoutProfileSelctedInTableView" object:self]; // notify other view that oscLayoutManager is closing
 }
 
-- (IBAction) deleteTapped:(id)sender{// delete can be executed simply by calling this 2 methods.
-    [profilesManager deleteCurrentSelectedProfile];
-    [self profileViewRefresh];
+- (IBAction) deleteTapped:(id)sender {
+    OSCProfile *currentProfile = [profilesManager getSelectedProfile];
+    if (!currentProfile || !currentProfile.name) {
+        return;
+    }
+    
+    // 检查是否为模板布局
+    if ([profilesManager isTemplateProfile:currentProfile.name]) {
+        NSString *message = [NSString stringWithFormat:@"模板布局'%@'不允许删除", currentProfile.name];
+        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"" message:message preferredStyle:UIAlertControllerStyleAlert];
+        
+        [alertController addAction:[UIAlertAction actionWithTitle:[LocalizationHelper localizedStringForKey:@"Ok"] style:UIAlertActionStyleDefault handler:nil]];
+        [self presentViewController:alertController animated:YES completion:nil];
+        return;
+    }
+    
+    // 删除确认弹窗
+    NSString *confirmMessage = [NSString stringWithFormat:@"确定要删除布局'%@'吗？", currentProfile.name];
+    UIAlertController *confirmController = [UIAlertController alertControllerWithTitle:@"确认删除" message:confirmMessage preferredStyle:UIAlertControllerStyleAlert];
+    
+    [confirmController addAction:[UIAlertAction actionWithTitle:@"取消" style:UIAlertActionStyleCancel handler:nil]];
+    [confirmController addAction:[UIAlertAction actionWithTitle:@"删除" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
+        [self->profilesManager deleteCurrentSelectedProfile];
+        [self profileViewRefresh];
+    }]];
+    
+    [self presentViewController:confirmController animated:YES completion:nil];
 }
 
 - (IBAction) exportDataTapped:(id)sender {
@@ -305,11 +354,50 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
 
 - (UITableViewCell *) tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     ProfileTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell" forIndexPath:indexPath];
-    OSCProfile *profile = [[profilesManager getAllProfiles] objectAtIndex:indexPath.row];
-    cell.name.text = profile.name;
+    NSMutableArray *allProfiles = [profilesManager getAllProfiles];
+    
+    // 安全检查：确保索引有效且profile不为nil
+    if (indexPath.row >= allProfiles.count) {
+        NSLog(@"错误：索引超出范围 %ld >= %lu", (long)indexPath.row, (unsigned long)allProfiles.count);
+        cell.name.text = @"错误：无效配置";
+        return cell;
+    }
+    
+    OSCProfile *profile = [allProfiles objectAtIndex:indexPath.row];
+    if (profile == nil) {
+        NSLog(@"错误：配置文件为nil，索引：%ld", (long)indexPath.row);
+        cell.name.text = @"错误：配置文件损坏";
+        return cell;
+    }
+    
+    // 构建显示文本，包含配对标识和模板标识
+    NSString *displayText = profile.name ?: @"未命名配置";  // 防止name为nil
+    
+    // 添加模板标识
+    if ([profilesManager isTemplateProfile:profile.name]) {
+        displayText = [NSString stringWithFormat:@"📋 %@", displayText];
+    }
+    
+    // 添加配对标识
+    if (profile.isPaired) {
+        NSString *orientationText = [self getOrientationDisplayText:profile.isLandscapeLayout];
+        displayText = [NSString stringWithFormat:@"%@ %@", orientationText, displayText];
+    }
+    
+    cell.name.text = displayText;
     cell.name.backgroundColor = [UIColor clearColor];
     cell.name.alpha = 1.0;
-    cell.name.textColor = [UIColor whiteColor];  // Opaque white text
+    
+    // 根据配对模式设置文本颜色和可选择性
+    BOOL canSelect = [self canSelectProfileForPairing:profile];
+    if (self.isPairingMode && !canSelect) {
+        cell.name.textColor = [UIColor grayColor];  // 不可选择的布局显示为灰色
+        cell.userInteractionEnabled = NO;
+    } else {
+        cell.name.textColor = [UIColor whiteColor];  // 正常白色文本
+        cell.userInteractionEnabled = YES;
+    }
+    
     cell.name.font =[UIFont systemFontOfSize:20 weight:UIFontWeightMedium];
     cell.name.shadowColor = [UIColor blackColor];  // Black shadow
     // Set the shadow offset
@@ -364,8 +452,22 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
 }
 
 - (BOOL) tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
-    return YES;
+    NSMutableArray *profiles = [profilesManager getAllProfiles];
+    
+    // 安全检查：确保索引有效
+    if (indexPath.row >= profiles.count) {
+        return NO;
+    }
+    
+    OSCProfile *profile = [profiles objectAtIndex:indexPath.row];
+    if (!profile || !profile.name) {
+        return NO;
+    }
+    
+    // 模板布局不允许删除
+    return ![profilesManager isTemplateProfile:profile.name];
 }
+
 
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
@@ -374,44 +476,78 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
 
 
 - (void) tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
-    NSMutableArray *profiles = [profilesManager getAllProfiles];
-
-    if ([[[profiles objectAtIndex:indexPath.row] name] isEqualToString:@"Default"]) {   // if user is attempting to delete the 'Default' profile then show a pop up telling user they can't do that and return out of this method
-        UIAlertController *alertController = [UIAlertController alertControllerWithTitle: [NSString stringWithFormat:@""] message: @"Deleting the 'Default' profile is not allowed" preferredStyle:UIAlertControllerStyleAlert];
+    if (editingStyle == UITableViewCellEditingStyleDelete) {
+        NSMutableArray *profiles = [profilesManager getAllProfiles];
         
-        [alertController addAction:[UIAlertAction actionWithTitle:[LocalizationHelper localizedStringForKey:@"Ok"] style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [alertController dismissViewControllerAnimated:NO completion:nil];
+        // 安全检查：确保索引有效
+        if (indexPath.row >= profiles.count) {
+            return;
+        }
+        
+        OSCProfile *profileToDelete = [profiles objectAtIndex:indexPath.row];
+        if (!profileToDelete || !profileToDelete.name) {
+            return;
+        }
+        
+        // 检查是否为模板布局
+        if ([profilesManager isTemplateProfile:profileToDelete.name]) {
+            NSString *message = [NSString stringWithFormat:@"删除'%@'模板布局是不被允许的", profileToDelete.name];
+            UIAlertController *alertController = [UIAlertController alertControllerWithTitle:@"" message:message preferredStyle:UIAlertControllerStyleAlert];
+            
+            [alertController addAction:[UIAlertAction actionWithTitle:[LocalizationHelper localizedStringForKey:@"Ok"] style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+                [alertController dismissViewControllerAnimated:NO completion:nil];
+            }]];
+            [self presentViewController:alertController animated:YES completion:nil];
+            return;
+        }
+        
+        // 删除确认弹窗
+        NSString *confirmMessage = [NSString stringWithFormat:@"确定要删除布局'%@'吗？", profileToDelete.name];
+        UIAlertController *confirmController = [UIAlertController alertControllerWithTitle:@"确认删除" message:confirmMessage preferredStyle:UIAlertControllerStyleAlert];
+        
+        [confirmController addAction:[UIAlertAction actionWithTitle:@"取消" style:UIAlertActionStyleCancel handler:nil]];
+        [confirmController addAction:[UIAlertAction actionWithTitle:@"删除" style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
+            [self performDeleteProfile:profileToDelete atIndexPath:indexPath];
         }]];
-        [self presentViewController:alertController animated:YES completion:nil];
         
-        return;
+        [self presentViewController:confirmController animated:YES completion:nil];
+    }
+}
+
+- (void)performDeleteProfile:(OSCProfile *)profileToDelete atIndexPath:(NSIndexPath *)indexPath {
+    NSMutableArray *profiles = [profilesManager getAllProfiles];
+    
+    // 处理删除选中布局的情况
+    if (profileToDelete.isSelected) {
+        if (indexPath.row > 0) {
+            OSCProfile *previousProfile = [profiles objectAtIndex:indexPath.row - 1];
+            previousProfile.isSelected = YES;
+        } else if (profiles.count > 1) {
+            OSCProfile *nextProfile = [profiles objectAtIndex:1];
+            nextProfile.isSelected = YES;
+        }
     }
     
-    if (editingStyle == UITableViewCellEditingStyleDelete) {
-        OSCProfile *profile = [profiles objectAtIndex:indexPath.row];
-        if (profile.isSelected) {   // if user is deleting the currently selected OSC profile then make the  profile at its previous index the currently selected profile
-            if (indexPath.row > 0) {    // check that row is greater than zero to avoid an out of bounds crash, although that should not be possible right now since the 'Default' profile is always at row 0 and they're not allowed to delete it
-                OSCProfile *profile = [profiles objectAtIndex:indexPath.row - 1];
-                profile.isSelected = YES;
-            }
-        }
-        
-        [profiles removeObjectAtIndex:indexPath.row];
-        
-        /* save OSC profiles array to persistent storage */
-        NSMutableArray *profilesEncoded = [[NSMutableArray alloc] init];
-        for (OSCProfile *profileDecoded in profiles) {  // encode each OSC profile object and add them to an array
-            
-            NSData *profileEncoded = [NSKeyedArchiver archivedDataWithRootObject:profileDecoded requiringSecureCoding:YES error:nil];
-            [profilesEncoded addObject:profileEncoded];
-        }
-        NSData *data = [NSKeyedArchiver archivedDataWithRootObject:profilesEncoded
-                                             requiringSecureCoding:YES error:nil];  // encode the array itself, NOT the objects in the array
-        [[NSUserDefaults standardUserDefaults] setObject:data forKey:@"OSCProfiles"];
-        [[NSUserDefaults standardUserDefaults] synchronize];
-        
-        [tableView reloadData]; 
+    // 如果要删除的布局是配对布局，解除配对关系
+    if (profileToDelete.isPaired) {
+        [profilesManager unpairProfile:profileToDelete.name];
     }
+    
+    [profiles removeObjectAtIndex:indexPath.row];
+    
+    /* save OSC profiles array to persistent storage */
+    NSMutableArray *profilesEncoded = [[NSMutableArray alloc] init];
+    for (OSCProfile *profileDecoded in profiles) {  // encode each OSC profile object and add them to an array
+        NSData *profileEncoded = [NSKeyedArchiver archivedDataWithRootObject:profileDecoded requiringSecureCoding:YES error:nil];
+        [profilesEncoded addObject:profileEncoded];
+    }
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:profilesEncoded
+                                         requiringSecureCoding:YES error:nil];  // encode the array itself, NOT the objects in the array
+    [[NSUserDefaults standardUserDefaults] setObject:data forKey:@"OSCProfiles"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+    
+    [self.tableView reloadData];
+    [self updateToolbarButtons];  // 更新工具栏按钮状态
 }
 
 
@@ -420,24 +556,438 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
 /* When user taps a cell it moves the checkmark to that cell indicating to the user the profile associated with that cell is now the selected profile. It also sets that cell's associated OSCProfile object's 'isSelected' property to YES  */
 - (void) tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
+    NSMutableArray *allProfiles = [profilesManager getAllProfiles];
+    
+    // 安全检查：确保索引有效
+    if (indexPath.row >= allProfiles.count) {
+        NSLog(@"错误：选择的索引超出范围 %ld >= %lu", (long)indexPath.row, (unsigned long)allProfiles.count);
+        [tableView deselectRowAtIndexPath:indexPath animated:YES];
+        return;
+    }
+    
+    OSCProfile *profile = [allProfiles objectAtIndex:indexPath.row];
+    if (profile == nil) {
+        NSLog(@"错误：选择的配置文件为nil，索引：%ld", (long)indexPath.row);
+        [tableView deselectRowAtIndexPath:indexPath animated:YES];
+        return;
+    }
+    
+    if (self.isPairingMode) {
+        // 配对模式：选择要配对的布局
+        if ([self canSelectProfileForPairing:profile]) {
+            self.selectedProfileForPairing = profile.name;
+            [self updateToolbarButtons];  // 更新保存按钮状态
+        }
+        [tableView deselectRowAtIndexPath:indexPath animated:YES];
+        return;
+    }
+    
+    // 普通模式：选择布局逻辑
     NSIndexPath *selectedIndexPath = [NSIndexPath indexPathForRow:indexPath.row inSection:0];
     NSIndexPath *lastSelectedIndexPath = [NSIndexPath indexPathForRow:[profilesManager getIndexOfSelectedProfile] inSection:0];
 
     if (selectedIndexPath != lastSelectedIndexPath) {
+        // 如果选择的是已配对的布局，需要检查是否应该切换到对应方向的布局
+        if (profile.isPaired) {
+            BOOL isCurrentLandscape = [profilesManager isCurrentOrientationLandscape];
+            OSCProfile *targetProfile = [profilesManager getProfileForCurrentOrientation:profile.name isLandscape:isCurrentLandscape];
+            if (targetProfile && ![targetProfile.name isEqualToString:profile.name]) {
+                // 切换到对应方向的布局
+                profile = targetProfile;
+                indexPath = [NSIndexPath indexPathForRow:[[profilesManager getAllProfiles] indexOfObject:targetProfile] inSection:0];
+                selectedIndexPath = indexPath;
+            }
+        }
+        
         /* Place checkmark on selected cell and set profile associated with cell as selected profile */
         UITableViewCell *selectedCell = [tableView cellForRowAtIndexPath: selectedIndexPath];
         selectedCell.accessoryType = UITableViewCellAccessoryCheckmark;  // add checkmark to the cell the user tapped
         selectedCell.accessoryView.tintColor = [[UIColor colorWithRed:0.5 green:0.5 blue:1.0 alpha:0.85] colorWithAlphaComponent:1.0];
-        OSCProfile *profile = [[profilesManager getAllProfiles] objectAtIndex:indexPath.row];
         [profilesManager setProfileToSelected: profile.name];   // set the profile associated with this cell's 'isSelected' property to YES
         
         /* Remove checkmark on the previously selected cell  */
         UITableViewCell *lastSelectedCell = [tableView cellForRowAtIndexPath: lastSelectedIndexPath];
         lastSelectedCell.accessoryType = UITableViewCellAccessoryNone; 
         [tableView deselectRowAtIndexPath:lastSelectedIndexPath animated:YES];
+        
+        // 更新工具栏按钮
+        [self updateToolbarButtons];
     }
     [self profileViewRefresh]; // update OSC layout when table view option is changed
 }
 
+#pragma mark - Pairing Management
+
+- (void)setupBottomToolbar {
+    NSLog(@"开始设置底部工具栏");
+    
+    // 创建底部工具栏视图（如果不存在）
+    if (!self.bottomToolbarView) {
+        NSLog(@"创建新的底部工具栏视图");
+        self.bottomToolbarView = [[UIView alloc] init];
+        if (!self.bottomToolbarView) {
+            NSLog(@"错误：无法创建bottomToolbarView");
+            return;
+        }
+        
+        // 设置工具栏样式
+        self.bottomToolbarView.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.8];
+        self.bottomToolbarView.layer.cornerRadius = 8;
+        self.bottomToolbarView.layer.masksToBounds = YES;
+        
+        self.bottomToolbarView.translatesAutoresizingMaskIntoConstraints = NO;
+        [self.view addSubview:self.bottomToolbarView];
+        NSLog(@"工具栏视图已添加到视图");
+        
+        // 创建约束
+        NSLayoutConstraint *leadingConstraint = [self.bottomToolbarView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:16];
+        NSLayoutConstraint *trailingConstraint = [self.bottomToolbarView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-16];
+        NSLayoutConstraint *bottomConstraint = [self.bottomToolbarView.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor constant:-16];
+        NSLayoutConstraint *heightConstraint = [self.bottomToolbarView.heightAnchor constraintEqualToConstant:50];
+        
+        // 检查约束是否创建成功
+        NSMutableArray *constraints = [[NSMutableArray alloc] init];
+        if (leadingConstraint) [constraints addObject:leadingConstraint];
+        if (trailingConstraint) [constraints addObject:trailingConstraint];
+        if (bottomConstraint) [constraints addObject:bottomConstraint];
+        if (heightConstraint) [constraints addObject:heightConstraint];
+        
+        if (constraints.count == 4) {
+            [NSLayoutConstraint activateConstraints:constraints];
+            NSLog(@"工具栏约束设置成功");
+        } else {
+            NSLog(@"错误：约束创建失败，成功创建 %lu/4 个约束", (unsigned long)constraints.count);
+        }
+        
+        // 确保工具栏在最前面
+        [self.view bringSubviewToFront:self.bottomToolbarView];
+    } else {
+        NSLog(@"工具栏已存在，跳过创建");
+    }
+    
+    [self updateToolbarButtons];
+}
+
+- (void)updateToolbarButtons {
+    // 如果工具栏不存在，直接返回
+    if (!self.bottomToolbarView) {
+        return;
+    }
+    
+    // 清除现有按钮
+    for (UIView *subview in self.bottomToolbarView.subviews) {
+        [subview removeFromSuperview];
+    }
+    
+    OSCProfile *selectedProfile = [profilesManager getSelectedProfile];
+    BOOL isCurrentProfilePaired = selectedProfile ? selectedProfile.isPaired : NO;
+    BOOL isLandscape = [profilesManager isCurrentOrientationLandscape];
+    
+    if (self.isPairingMode) {
+        // 配对模式：显示保存和取消按钮
+        [self createPairingModeButtons];
+    } else {
+        // 普通模式：检查是否为模板布局
+        if (selectedProfile && [profilesManager isTemplateProfile:selectedProfile.name]) {
+            // 模板布局不显示配对相关按钮
+            return;
+        }
+        
+        // 普通模式：显示配对/解除配对按钮
+        NSString *buttonTitle;
+        SEL buttonAction;
+        
+        if (isCurrentProfilePaired) {
+            buttonTitle = @"解除配对";
+            buttonAction = @selector(unpairTapped:);
+        } else {
+            NSString *oppositeOrientation = isLandscape ? @"竖屏" : @"横屏";
+            buttonTitle = [NSString stringWithFormat:@"添加%@布局", oppositeOrientation];
+            buttonAction = @selector(startPairingTapped:);
+        }
+        
+        [self createNormalModeButtonWithTitle:buttonTitle action:buttonAction];
+    }
+}
+
+- (void)createPairingModeButtons {
+    // 创建取消按钮
+    self.cancelButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.cancelButton setTitle:@"取消" forState:UIControlStateNormal];
+    [self.cancelButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+    [self.cancelButton addTarget:self action:@selector(cancelPairingTapped:) forControlEvents:UIControlEventTouchUpInside];
+    self.cancelButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.bottomToolbarView addSubview:self.cancelButton];
+    
+    // 创建保存按钮
+    self.saveButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.saveButton setTitle:@"保存" forState:UIControlStateNormal];
+    [self.saveButton setTitleColor:[UIColor systemBlueColor] forState:UIControlStateNormal];
+    [self.saveButton setTitleColor:[UIColor grayColor] forState:UIControlStateDisabled];
+    [self.saveButton addTarget:self action:@selector(savePairingTapped:) forControlEvents:UIControlEventTouchUpInside];
+    self.saveButton.enabled = (self.selectedProfileForPairing != nil);
+    self.saveButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.bottomToolbarView addSubview:self.saveButton];
+    
+    // 设置约束
+    [NSLayoutConstraint activateConstraints:@[
+        [self.cancelButton.leadingAnchor constraintEqualToAnchor:self.bottomToolbarView.leadingAnchor constant:16],
+        [self.cancelButton.centerYAnchor constraintEqualToAnchor:self.bottomToolbarView.centerYAnchor],
+        
+        [self.saveButton.trailingAnchor constraintEqualToAnchor:self.bottomToolbarView.trailingAnchor constant:-16],
+        [self.saveButton.centerYAnchor constraintEqualToAnchor:self.bottomToolbarView.centerYAnchor]
+    ]];
+    
+    NSLog(@"配对模式按钮创建成功");
+}
+
+- (void)createNormalModeButtonWithTitle:(NSString *)title action:(SEL)action {
+    // 创建主按钮
+    self.pairingButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.pairingButton setTitle:title forState:UIControlStateNormal];
+    [self.pairingButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+    [self.pairingButton addTarget:self action:action forControlEvents:UIControlEventTouchUpInside];
+    self.pairingButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.bottomToolbarView addSubview:self.pairingButton];
+    
+    // 设置约束 - 居中显示
+    [NSLayoutConstraint activateConstraints:@[
+        [self.pairingButton.centerXAnchor constraintEqualToAnchor:self.bottomToolbarView.centerXAnchor],
+        [self.pairingButton.centerYAnchor constraintEqualToAnchor:self.bottomToolbarView.centerYAnchor]
+    ]];
+    
+    NSLog(@"普通模式按钮创建成功：%@", title);
+}
+
+- (IBAction)startPairingTapped:(id)sender {
+    self.isPairingMode = YES;
+    self.selectedProfileForPairing = nil;
+    [self updateToolbarButtons];
+    [self.tableView reloadData];
+}
+
+- (IBAction)unpairTapped:(id)sender {
+    OSCProfile *selectedProfile = [profilesManager getSelectedProfile];
+    if (selectedProfile && selectedProfile.isPaired) {
+        [profilesManager unpairProfile:selectedProfile.name];
+        [self updateToolbarButtons];
+        [self.tableView reloadData];
+    }
+}
+
+- (IBAction)savePairingTapped:(id)sender {
+    if (self.selectedProfileForPairing) {
+        OSCProfile *currentProfile = [profilesManager getSelectedProfile];
+        if (currentProfile == nil || currentProfile.name == nil) {
+            NSLog(@"错误：当前选中的配置文件无效，无法进行配对");
+            return;
+        }
+        
+        BOOL isCurrentLandscape = [profilesManager isCurrentOrientationLandscape];
+        
+        BOOL success = [profilesManager pairProfile:currentProfile.name 
+                                        withProfile:self.selectedProfileForPairing 
+                                   isProfile1Landscape:isCurrentLandscape];
+        
+        if (success) {
+            self.isPairingMode = NO;
+            self.selectedProfileForPairing = nil;
+            [self updateToolbarButtons];
+            [self.tableView reloadData];
+        } else {
+            NSLog(@"配对失败");
+        }
+    }
+}
+
+- (IBAction)cancelPairingTapped:(id)sender {
+    self.isPairingMode = NO;
+    self.selectedProfileForPairing = nil;
+    [self updateToolbarButtons];
+    [self.tableView reloadData];
+}
+
+- (NSString *)getOrientationDisplayText:(BOOL)isLandscape {
+    return isLandscape ? @"[横]" : @"[竖]";
+}
+
+- (BOOL)canSelectProfileForPairing:(OSCProfile *)profile {
+    if (!self.isPairingMode) return YES;
+    
+    OSCProfile *currentProfile = [profilesManager getSelectedProfile];
+    
+    // 不能选择当前使用的布局
+    if ([profile.name isEqualToString:currentProfile.name]) {
+        return NO;
+    }
+    
+    // 不能选择已配对的布局
+    if (profile.isPaired) {
+        return NO;
+    }
+    
+    // 不能选择模板布局
+    if ([profilesManager isTemplateProfile:profile.name]) {
+        return NO;
+    }
+    
+    return YES;
+}
+
+- (void)deviceOrientationDidChange:(NSNotification *)notification {
+    // 如果正在配对模式，不处理自动切换
+    if (self.isPairingMode) {
+        return;
+    }
+    
+    // 如果正在处理方向变化，跳过重复处理
+    if (self.isProcessingOrientationChange) {
+        return;
+    }
+    
+    self.isProcessingOrientationChange = YES;
+    
+    // 延迟一小段时间，让旋转完成后再检测方向
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self performPairedLayoutSwitchingForTableView];
+        // 简化：处理完成后立即重置标志
+        self.isProcessingOrientationChange = NO;
+    });
+}
+
+- (void)performPairedLayoutSwitchingForTableView {
+    OSCProfile *currentProfile = [profilesManager getSelectedProfile];
+    if (!currentProfile || !currentProfile.isPaired) {
+        return;
+    }
+    
+    // 使用当前视图的bounds来检测方向，而不是依赖OSCProfilesManager的方法
+    BOOL isCurrentLandscape = self.view.bounds.size.width > self.view.bounds.size.height;
+    
+    OSCProfile *targetProfile = [profilesManager getProfileForCurrentOrientation:currentProfile.name isLandscape:isCurrentLandscape];
+    
+    if (targetProfile && ![targetProfile.name isEqualToString:currentProfile.name]) {
+        // 切换到目标布局
+        [profilesManager setProfileToSelected:targetProfile.name];
+        
+        // 更新UI - 这是关键，确保绿色小勾更新到新选中的布局
+        [self.tableView reloadData];
+        [self updateToolbarButtons];
+        
+        // 滚动到新选中的布局
+        NSInteger selectedIndex = [profilesManager getIndexOfSelectedProfile];
+        if (selectedIndex >= 0 && selectedIndex < [[profilesManager getAllProfiles] count]) {
+            NSIndexPath *indexPath = [NSIndexPath indexPathForRow:selectedIndex inSection:0];
+            [self.tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionMiddle animated:YES];
+        }
+    }
+}
+
+- (void)dealloc {
+    // 移除通知监听
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
+}
+
+#pragma mark - Delete Button State Management
+
+- (void)updateDeleteButtonState {
+    OSCProfile *currentProfile = [profilesManager getSelectedProfile];
+    BOOL isTemplateProfile = currentProfile && [profilesManager isTemplateProfile:currentProfile.name];
+    
+    // 尝试通过多种方式找到删除按钮并更新其状态
+    [self updateDeleteButtonWithTemplateState:isTemplateProfile];
+}
+
+- (void)updateDeleteButtonWithTemplateState:(BOOL)isTemplate {
+    // 方法1: 通过NavigationBar的rightBarButtonItems查找
+    if (self.navigationController && self.navigationController.navigationBar) {
+        UINavigationBar *navBar = self.navigationController.navigationBar;
+        UINavigationItem *navItem = navBar.topItem;
+        
+        if (navItem.rightBarButtonItems) {
+            for (UIBarButtonItem *item in navItem.rightBarButtonItems) {
+                // 检查按钮标题或者action来识别删除按钮
+                if ([item.title isEqualToString:@"删除"] || 
+                    [item.title isEqualToString:@"Delete"] ||
+                    item.action == @selector(deleteTapped:)) {
+                    item.enabled = !isTemplate;
+                    NSLog(@"通过NavigationBar找到删除按钮，设置enabled=%@", isTemplate ? @"NO" : @"YES");
+                    return;
+                }
+            }
+        }
+        
+        if (navItem.rightBarButtonItem) {
+            UIBarButtonItem *item = navItem.rightBarButtonItem;
+            if ([item.title isEqualToString:@"删除"] || 
+                [item.title isEqualToString:@"Delete"] ||
+                item.action == @selector(deleteTapped:)) {
+                item.enabled = !isTemplate;
+                NSLog(@"通过NavigationBar找到删除按钮，设置enabled=%@", isTemplate ? @"NO" : @"YES");
+                return;
+            }
+        }
+    }
+    
+    // 方法2: 通过profileTableViewNavigationBar查找
+    if (self.profileTableViewNavigationBar) {
+        UINavigationItem *navItem = self.profileTableViewNavigationBar.topItem;
+        
+        if (navItem.rightBarButtonItems) {
+            for (UIBarButtonItem *item in navItem.rightBarButtonItems) {
+                if ([item.title isEqualToString:@"删除"] || 
+                    [item.title isEqualToString:@"Delete"] ||
+                    item.action == @selector(deleteTapped:)) {
+                    item.enabled = !isTemplate;
+                    NSLog(@"通过profileTableViewNavigationBar找到删除按钮，设置enabled=%@", isTemplate ? @"NO" : @"YES");
+                    return;
+                }
+            }
+        }
+        
+        if (navItem.rightBarButtonItem) {
+            UIBarButtonItem *item = navItem.rightBarButtonItem;
+            if ([item.title isEqualToString:@"删除"] || 
+                [item.title isEqualToString:@"Delete"] ||
+                item.action == @selector(deleteTapped:)) {
+                item.enabled = !isTemplate;
+                NSLog(@"通过profileTableViewNavigationBar找到删除按钮，设置enabled=%@", isTemplate ? @"NO" : @"YES");
+                return;
+            }
+        }
+    }
+    
+    // 方法3: 递归搜索view hierarchy中的删除按钮
+    [self findAndUpdateDeleteButtonInView:self.view isTemplate:isTemplate];
+}
+
+- (void)findAndUpdateDeleteButtonInView:(UIView *)view isTemplate:(BOOL)isTemplate {
+    for (UIView *subview in view.subviews) {
+        if ([subview isKindOfClass:[UIButton class]]) {
+            UIButton *button = (UIButton *)subview;
+            NSString *title = [button titleForState:UIControlStateNormal];
+            
+            // 检查按钮的标题或action
+            if ([title isEqualToString:@"删除"] || 
+                [title isEqualToString:@"Delete"] ||
+                [button actionsForTarget:self forControlEvent:UIControlEventTouchUpInside].count > 0) {
+                
+                // 检查action是否为deleteTapped
+                NSArray *actions = [button actionsForTarget:self forControlEvent:UIControlEventTouchUpInside];
+                for (NSString *action in actions) {
+                    if ([action isEqualToString:@"deleteTapped:"]) {
+                        button.enabled = !isTemplate;
+                        button.alpha = isTemplate ? 0.5 : 1.0; // 置灰效果
+                        NSLog(@"通过view hierarchy找到删除按钮，设置enabled=%@", isTemplate ? @"NO" : @"YES");
+                        return;
+                    }
+                }
+            }
+        }
+        
+        // 递归搜索子视图
+        [self findAndUpdateDeleteButtonInView:subview isTemplate:isTemplate];
+    }
+}
 
 @end

--- a/VoidLink/ViewControllers/CustomOSCViewControl/OSCProfilesTableViewController.m
+++ b/VoidLink/ViewControllers/CustomOSCViewControl/OSCProfilesTableViewController.m
@@ -248,6 +248,15 @@ const double NAV_BAR_HEIGHT = 50;
         }]];
 
         [self presentViewController:inputNameAlertController animated:YES completion:nil];
+        
+        // 复制流程创建后，可能从模板切换到新布局，需要同步底部 toolbar 状态
+        // 在下一个 runloop 刷新，确保 selectedProfile 已更新
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self updateToolbarButtons];
+            if (self.systemBottomToolbar) {
+                [self updateSystemToolbarItems];
+            }
+        });
 }
 
 /* basically the same with loadTapped */
@@ -256,6 +265,7 @@ const double NAV_BAR_HEIGHT = 50;
     //[selfparentLayoutOSCViewController]
     [self.tableView reloadData]; // table view will be refreshed by calling reloadData
     [self updateDeleteButtonState]; // 更新顶部删除按钮状态
+    [self updateToolbarButtons]; // 同步底部 toolbar（系统/自定义）状态
     if (self.needToUpdateOscLayoutTVC) {    // tells the presenting view controller to lay out the on screen buttons according to the selected profile's instructions
         self.needToUpdateOscLayoutTVC();
     }

--- a/VoidLink/ViewControllers/StreamFrameViewController.m
+++ b/VoidLink/ViewControllers/StreamFrameViewController.m
@@ -23,9 +23,9 @@
 #import "MetalVideoRenderer.h"
 #import "CustomEdgeSlideGestureRecognizer.h"
 #import "CustomTapGestureRecognizer.h"
+#import "OSCProfilesManager.h"
 #import "LocalizationHelper.h"
 #import "VoidLink-Swift.h"
-#import "OSCProfilesManager.h"
 #import "ThemeManager.h"
 
 #include <sys/socket.h>
@@ -997,10 +997,15 @@
 }
 
 - (void) handleViewResize{
+    NSLog(@"🔄 StreamFrameViewController handleViewResize 开始");
     viewIsBeingResized = true;
     _streamView.bounds = _deviceWindow.bounds;
     _streamView.frame = _deviceWindow.frame;
-    if(![self isAirPlaying]){
+    
+    BOOL isAirPlaying = [self isAirPlaying];
+    NSLog(@"📺 AirPlay状态: %@", isAirPlaying ? @"正在AirPlay" : @"未使用AirPlay");
+    
+    if(!isAirPlaying){
         _streamVideoRenderView.bounds = _deviceWindow.bounds;
         _streamVideoRenderView.frame = _deviceWindow.frame;
 
@@ -1014,11 +1019,88 @@
         
         // Handle resize for AVSB renderer
         NSNotificationCenter* nc = [NSNotificationCenter defaultCenter];
+        NSLog(@"📡 发送 ScreenChanged 通知");
         [nc postNotificationName:@"ScreenChanged" object:self];
+        
+        // 处理配对布局切换
+        BOOL didSwitchPairedLayout = [self handlePairedLayoutSwitching];
+        
+        // 如果切换了配对布局，延迟调用reConfigStreamViewRealtime以避免重叠
+        if (didSwitchPairedLayout) {
+            NSLog(@"🔄 配对布局已切换，延迟0.1秒后调用reConfigStreamViewRealtime");
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                NSLog(@"⏰ 延迟调用开始 - reConfigStreamViewRealtimeAndReloadSettings:NO");
+                
+                // 再次验证当前选中的布局
+                OSCProfilesManager *profilesManager = [OSCProfilesManager sharedManager:self.view.bounds];
+                OSCProfile *currentProfile = [profilesManager getSelectedProfile];
+                NSLog(@"🔍 延迟调用时的当前选中布局: %@", currentProfile ? currentProfile.name : @"无");
+                
+                [self reConfigStreamViewRealtimeAndReloadSettings:NO]; // 不重新加载设置，避免覆盖配对布局
+                NSLog(@"✅ 延迟调用完成");
+            });
+        } else {
+            [self reConfigStreamViewRealtime];
+        }
+    } else {
+        NSLog(@"⚠️ 因为AirPlay状态，跳过发送ScreenChanged通知");
+        [self reConfigStreamViewRealtime];
     }
-    [self reConfigStreamViewRealtime];
+    NSLog(@"✅ StreamFrameViewController handleViewResize 完成");
 }
 
+- (BOOL)handlePairedLayoutSwitching {
+    NSLog(@"=== StreamFrameViewController 配对布局切换处理开始 ===");
+    
+    // 获取OSCProfilesManager实例
+    OSCProfilesManager *profilesManager = [OSCProfilesManager sharedManager:self.view.bounds];
+    
+    // 检查当前布局是否已配对，如果是则切换到配对布局
+    OSCProfile *currentProfile = [profilesManager getSelectedProfile];
+    NSLog(@"当前选中布局: %@", currentProfile ? currentProfile.name : @"无");
+    
+    if (currentProfile) {
+        NSLog(@"当前布局是否已配对: %@", currentProfile.isPaired ? @"是" : @"否");
+        NSLog(@"当前布局方向标记: %@ (isLandscapeLayout=%@)", 
+              currentProfile.isLandscapeLayout ? @"横屏" : @"竖屏",
+              currentProfile.isLandscapeLayout ? @"YES" : @"NO");
+        NSLog(@"配对的布局名称: %@", currentProfile.pairedProfileName ?: @"无");
+        
+        if (currentProfile.isPaired) {
+            BOOL isCurrentLandscape = [profilesManager isCurrentOrientationLandscape];
+            NSLog(@"当前实际屏幕方向: %@", isCurrentLandscape ? @"横屏" : @"竖屏");
+            
+            OSCProfile *targetProfile = [profilesManager getProfileForCurrentOrientation:currentProfile.name isLandscape:isCurrentLandscape];
+            NSLog(@"目标布局: %@", targetProfile ? targetProfile.name : @"无");
+            
+            if (targetProfile && ![targetProfile.name isEqualToString:currentProfile.name]) {
+                // 切换到配对的布局
+                NSLog(@"🔄 执行布局切换：从 %@ 切换到 %@", currentProfile.name, targetProfile.name);
+                [profilesManager setProfileToSelected:targetProfile.name];
+                NSLog(@"✅ 布局切换完成");
+                
+                // 验证切换是否成功
+                OSCProfile *verifyProfile = [profilesManager getSelectedProfile];
+                NSLog(@"🔍 验证切换结果 - 当前选中布局: %@", verifyProfile ? verifyProfile.name : @"无");
+                
+                // 不在这里重新加载屏幕控件，让延迟的reConfigStreamViewRealtime来处理
+                NSLog(@"ℹ️ 跳过立即重新加载屏幕控件，等待延迟调用处理");
+                
+                NSLog(@"=== StreamFrameViewController 配对布局切换处理结束 ===");
+                return YES; // 返回YES表示进行了布局切换
+            } else {
+                NSLog(@"❌ 不需要切换布局 - 目标布局与当前布局相同或目标布局为空");
+            }
+        } else {
+            NSLog(@"ℹ️ 当前布局未配对，使用自适应逻辑");
+        }
+    } else {
+        NSLog(@"❌ 没有选中的布局");
+    }
+    
+    NSLog(@"=== StreamFrameViewController 配对布局切换处理结束 ===");
+    return NO; // 返回NO表示没有进行布局切换
+}
 
 // This will fire if the user opens control center or gets a low battery message
 - (void)applicationWillResignActive:(NSNotification *)notification {
@@ -1553,13 +1635,16 @@
 #endif
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    NSLog(@"📱 StreamFrameViewController viewWillTransitionToSize: %@ -> %@", NSStringFromCGSize(self.view.bounds.size), NSStringFromCGSize(size));
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     
     if (_isRestoringFromPiP) {
+        NSLog(@"⚠️ PiP恢复中，跳过重新配置");
         Log(LOG_I, @"View size changed during PiP restore, skipping redundant reconfiguration.");
         return;
     }
 
+    NSLog(@"🔄 准备在0.2秒后调用handleViewResize");
     Log(LOG_I, @"View size changed, terminating stream");
     
     double delayInSeconds = 0.2;

--- a/VoidLink/mul.lproj/iPad.xcstrings
+++ b/VoidLink/mul.lproj/iPad.xcstrings
@@ -343,6 +343,18 @@
         }
       }
     },
+    "7rN-Nu-Vqg.title" : {
+      "comment" : "Class = \"UIBarButtonItem\"; title = \"Item\"; ObjectID = \"7rN-Nu-Vqg\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Item"
+          }
+        }
+      }
+    },
     "7tq-jU-C6l.text" : {
       "comment" : "Class = \"UILabel\"; text = \"Gyro Mode\"; ObjectID = \"7tq-jU-C6l\";",
       "extractionState" : "extracted_with_value",
@@ -819,6 +831,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "啟用螢幕小工具與外設"
+          }
+        }
+      }
+    },
+    "aqk-2z-ycj.title" : {
+      "comment" : "Class = \"UIBarButtonItem\"; title = \"Pair Rotational Layout\"; ObjectID = \"aqk-2z-ycj\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pair Rotational Layout"
           }
         }
       }

--- a/VoidLink/mul.lproj/iPhone.xcstrings
+++ b/VoidLink/mul.lproj/iPhone.xcstrings
@@ -91,6 +91,18 @@
         }
       }
     },
+    "3bT-QF-0LO.title" : {
+      "comment" : "Class = \"UIBarButtonItem\"; title = \"Item\"; ObjectID = \"3bT-QF-0LO\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Item"
+          }
+        }
+      }
+    },
     "3Hh-2q-gas.text" : {
       "comment" : "Class = \"UILabel\"; text = \"Preferred Codec\"; ObjectID = \"3Hh-2q-gas\";",
       "extractionState" : "extracted_with_value",
@@ -963,6 +975,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "完整"
+          }
+        }
+      }
+    },
+    "BIT-3F-bXp.title" : {
+      "comment" : "Class = \"UIBarButtonItem\"; title = \"Pair Rotational Layout\"; ObjectID = \"BIT-3F-bXp\";",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pair Rotational Layout"
           }
         }
       }


### PR DESCRIPTION
当前的屏幕按键自适应布局很好地解决了旋转屏幕后按键会超出去的情况，但重度使用两个方向的情况下，自适应按键布局还是不够顺手。这个提交创建了按键布局配对的功能，允许用户把配置好的横屏和竖屏布局绑定，绑定后旋转屏幕只在这两个布局之间切换。

其它改动：
- 翻新了按键布局列表浮层
- 默认的三个布局都不允许删除和编辑
- 自定义布局删除前有 alert 提示


![dc815166b77a4acd5e24e6cf723e8ba2](https://github.com/user-attachments/assets/cbcd6925-33f0-4cc7-843a-396a66730a7f)

![6eabcade3bb962f0d17059ff0553ab1a](https://github.com/user-attachments/assets/d4ea393d-dbb3-412d-9c7d-0230eeebbec2)
