### PR TITLE
修正：允許別名輸入欄使用預設鍵盤（支援注音/中文輸入法）

### DIFF
--- a/VoidLink/ViewControllers/CustomOSCViewControl/LayoutOnScreenControlsViewController.m
+++ b/VoidLink/ViewControllers/CustomOSCViewControl/LayoutOnScreenControlsViewController.m
@@ -487,7 +487,7 @@
     
     [alertController addTextFieldWithConfigurationHandler:^(UITextField *textField) {
         textField.placeholder = [LocalizationHelper localizedStringForKey:@"Alias label (optional)"];
-        textField.keyboardType = UIKeyboardTypeASCIICapable;
+        textField.keyboardType = UIKeyboardTypeDefault;
         textField.autocorrectionType = UITextAutocorrectionTypeNo;
         textField.spellCheckingType = UITextSpellCheckingTypeNo;
     }];
@@ -558,7 +558,7 @@
     
     [alertController addTextFieldWithConfigurationHandler:^(UITextField *textField) {
         textField.placeholder = [LocalizationHelper localizedStringForKey:@"Alias label (optional)"];
-        textField.keyboardType = UIKeyboardTypeASCIICapable;
+        textField.keyboardType = UIKeyboardTypeDefault;
         textField.autocorrectionType = UITextAutocorrectionTypeNo;
         textField.spellCheckingType = UITextSpellCheckingTypeNo;
         textField.text = self->selectedWidgetView.widgetLabel;

--- a/VoidLink/ViewControllers/ToolboxViewController.swift
+++ b/VoidLink/ViewControllers/ToolboxViewController.swift
@@ -224,7 +224,7 @@ import UIKit
         alert.textFields?[0].keyboardType = .asciiCapable
         alert.textFields?[0].autocorrectionType = .no
         alert.textFields?[0].spellCheckingType = .no
-        alert.textFields?[1].keyboardType = .asciiCapable
+        alert.textFields?[1].keyboardType = .default
         alert.textFields?[1].autocorrectionType = .no
         alert.textFields?[1].spellCheckingType = .no
 


### PR DESCRIPTION
本次 PR 將工具箱「指令別名」與螢幕小工具「別名標籤」的輸入欄位，鍵盤類型由 .asciiCapable 改為 .default。

原因 (Reason)：

使用 .asciiCapable 時，iOS 會限制只能開啟英文鍵盤。

使用者無法切換到注音或其他中文輸入法，造成不便。

改用 .default 後，使用者可自由切換注音、倉頡、拼音等輸入法，也能正常輸入英文。

修改內容 (Changes)：

將相關輸入框的 keyboardType 屬性改為 .default。

已在 iOS 上驗證，可以正常切換注音輸入法。

影響 (Impact)：

改善繁體中文使用者的輸入體驗。

對英文輸入沒有任何副作用。