### PR TITLE
Fall back to phone haptics engine if controller doesn't support it

### DIFF
--- a/VoidLink/Input/HapticContext.m
+++ b/VoidLink/Input/HapticContext.m
@@ -100,6 +100,10 @@
             Log(LOG_W, @"Controller %d falls back to use iPhone Haptics for locality: %@", gamepad.playerIndex, locality);
             NSError *error = nil;
             _hapticEngine = [[CHHapticEngine alloc] initAndReturnError:&error];
+            if (error != nil) {
+                Log(LOG_W, @"Controller %d: iPhone Haptic engine failed to start: %@", gamepad.playerIndex, error);
+                return nil;
+            }
         }
         else {
             return nil;

--- a/VoidLink/Input/HapticContext.m
+++ b/VoidLink/Input/HapticContext.m
@@ -84,18 +84,32 @@
 }
 
 -(id) initWithGamepad:(GCController*)gamepad locality:(GCHapticsLocality)locality API_AVAILABLE(ios(14.0), tvos(14.0)) {
+    bool needFallBackToPhoneHaptics = false;
+    
     if (gamepad.haptics == nil) {
         Log(LOG_W, @"Controller %d does not support haptics", gamepad.playerIndex);
-        return nil;
+        needFallBackToPhoneHaptics = true;
+    }
+    else if (![[gamepad.haptics supportedLocalities] containsObject:locality]) {
+        Log(LOG_W, @"Controller %d does not support haptic locality: %@", gamepad.playerIndex, locality);
+        needFallBackToPhoneHaptics = true;
     }
     
-    if (![[gamepad.haptics supportedLocalities] containsObject:locality]) {
-        Log(LOG_W, @"Controller %d does not support haptic locality: %@", gamepad.playerIndex, locality);
-        return nil;
+    if (needFallBackToPhoneHaptics) {
+        if (@available(iOS 13.0, *)) {
+            Log(LOG_W, @"Controller %d falls back to use iPhone Haptics for locality: %@", gamepad.playerIndex, locality);
+            NSError *error = nil;
+            _hapticEngine = [[CHHapticEngine alloc] initAndReturnError:&error];
+        }
+        else {
+            return nil;
+        }
+    }
+    else {
+        _hapticEngine = [gamepad.haptics createEngineWithLocality:locality];
     }
     
     _playerIndex = gamepad.playerIndex;
-    _hapticEngine = [gamepad.haptics createEngineWithLocality:locality];
     
     NSError* error;
     [_hapticEngine startAndReturnError:&error];


### PR DESCRIPTION
Fall back to phone haptics engine if controller doesn't support it

The code change from a youtube video and the original moonlight-ios repo doesn't work for me, I also see a port of that here:
https://github.com/The-Fried-Fish/VoidLink-previously-moonlight-zwm/pull/114

During my test, it will exit on this condition, MFi controller doesn't support haptics at all.
```
    if (gamepad.haptics == nil) {
        Log(LOG_W, @"Controller %d does not support haptics", gamepad.playerIndex);
        return nil;
    }
```
Then I made more changes here to handle both cases, and use phone haptics engine
1. Controller doesn't support haptics at all
2. Controller support haptics, but doesn't support one of the haptics locality (Left Handle, Right Handle, Left Trigger, Right Trigger)


Tested on iPhone 16 Pro Max (iOS26) + Razer Kishi Ultra (MFi Controller)

XCode logging shows 
<img width="1135" height="359" alt="Screenshot 2025-09-27 at 1 23 15 PM" src="https://github.com/user-attachments/assets/c83acab7-720b-4a07-8bb7-5e2b5c30045b" />

